### PR TITLE
fix: harden Jinja2 with SandboxedEnvironment and scope CI tokens (signed; replaces #322)

### DIFF
--- a/.github/actions/build-stlite/action.yml
+++ b/.github/actions/build-stlite/action.yml
@@ -74,16 +74,13 @@ runs:
       run: |
         npm run dump
 
-    - name: Set GITHUB_TOKEN
-      shell: bash
-      run: |
-        echo "GITHUB_TOKEN=${{ inputs.github-token }}" >> "$GITHUB_ENV"
-        echo "GH_TOKEN=${{ inputs.github-token }}" >> "$GITHUB_ENV"
-
     - name: Build
       shell: bash
       run: |
         npm run dist
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GH_TOKEN: ${{ inputs.github-token }}
 
     - name: Archive artifact (Windows)
       if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/reusable-test-and-build.yml
+++ b/.github/workflows/reusable-test-and-build.yml
@@ -255,12 +255,10 @@ jobs:
         with:
           fetch-depth: ALL_FETCH_DEPTH
 
-      - name: Set GITHUB_TOKEN
-        run: |
-          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> "$GITHUB_ENV"
-
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Convert SARIF to Markdown Summary
         uses: ./.github/actions/convert-sarif-to-summary

--- a/features/document_render.py
+++ b/features/document_render.py
@@ -90,8 +90,9 @@ from typing import (
 )
 
 import jinja2
-from jinja2 import Environment, Template, nodes
+from jinja2 import Template, nodes
 from jinja2.runtime import StrictUndefined, Undefined
+from jinja2.sandbox import SandboxedEnvironment
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, ValidationError
 
 from .validate_template import TemplateSecurityValidator, ValidationState
@@ -473,7 +474,7 @@ class DocumentRender(BaseModel):
             Optional[str]: レンダリング結果 (エラー時はNone)
         """
         try:
-            env: Environment = self._create_environment()
+            env: SandboxedEnvironment = self._create_environment()
             template: Template = env.from_string(template_content)
             return template.render(**context)
         except Exception as e:
@@ -577,16 +578,17 @@ class DocumentRender(BaseModel):
             return False
         return True
 
-    def _create_environment(self) -> Environment:
+    def _create_environment(self) -> SandboxedEnvironment:
         """Jinja2環境を作成する。
 
         カスタムフィルターやセキュリティ設定を含む環境を作成します。
         デフォルトでHTMLエスケープを有効化し、安全性を確保します。
+        SandboxedEnvironmentを使用して、テンプレート内からの危険な操作を防止します。
 
         Returns:
-            Environment: 設定済みのJinja2環境
+            SandboxedEnvironment: 設定済みのJinja2サンドボックス環境
         """
-        env: Environment = Environment(
+        env: SandboxedEnvironment = SandboxedEnvironment(
             autoescape=True,  # HTMLエスケープをデフォルトで有効化
             undefined=StrictUndefined if self._is_strict_undefined else CustomUndefined,
             extensions=["jinja2.ext.do"],  # 'do'拡張を有効化

--- a/features/validate_template.py
+++ b/features/validate_template.py
@@ -74,7 +74,8 @@ from typing import (
 )
 
 import jinja2
-from jinja2 import Environment, nodes
+from jinja2 import nodes
+from jinja2.sandbox import SandboxedEnvironment
 from markupsafe import Markup
 from pydantic import (
     BaseModel,
@@ -908,7 +909,7 @@ class TemplateSecurityValidator(BaseModel):
             Optional[nodes.Template]: 構文解析結果 (エラーの場合はNone)
         """
         try:
-            env = Environment(autoescape=True, extensions=["jinja2.ext.do"])
+            env = SandboxedEnvironment(autoescape=True, extensions=["jinja2.ext.do"])
             return env.parse(template_content)
         except jinja2.TemplateSyntaxError as e:
             validation_state.set_error(f"Template syntax error: {e!s}")

--- a/tests/unit/test_document_render.py
+++ b/tests/unit/test_document_render.py
@@ -1274,10 +1274,10 @@ def create_template_file() -> Callable[[bytes, str], BytesIO]:
             FORMAT_TYPE_COMPRESS_ALT,
             STRICT_UNDEFINED,
             {"limit": 1000000},
-            "",
+            None,
             EXPECTED_INITIAL_NO_ERROR,
-            EXPECTED_RUNTIME_NO_ERROR,
-            id="test_render_success_dynamic_loop_range_over_limit_strict",
+            "Template runtime error: Range too big. The sandbox blocks ranges larger than MAX_RANGE (100000).",
+            id="test_render_failure_dynamic_loop_range_over_sandbox_limit_strict",
         ),
         pytest.param(
             b"{% for i in range(limit) %}{% for j in range(limit) %}{% endfor %}{% endfor %}",


### PR DESCRIPTION
## Summary

This PR reproduces the exact change set of #322 as a single
**signed** commit so it can be merged under the `main` branch's
"Require signed commits" rule. #322 was blocked because its head commit
(authored by the Devin bot) was not signed, and a squash-merge was not
permitted for a non-author. See #325 for the root-cause writeup.

The diff is identical to #322 (+18 / -20, 5 files); only the commit
signature differs. No behavioral change versus #322.

### Changes (unchanged from #322)
1. `features/document_render.py`, `features/validate_template.py`:
   switch `jinja2.Environment` to `jinja2.sandbox.SandboxedEnvironment`
   for engine-level defense-in-depth (sandbox enforces `MAX_RANGE`).
2. `tests/unit/test_document_render.py`: the over-limit `range()` case
   now expects sandbox enforcement (`MAX_RANGE=100000`).
3. `.github/workflows/reusable-test-and-build.yml`,
   `.github/actions/build-stlite/action.yml`: scope `GITHUB_TOKEN`
   (and `GH_TOKEN`) to the steps that need it via step-level `env:`
   instead of exporting them to `$GITHUB_ENV` for all later steps.

### Review checklist (carried over from #322)
- [ ] Template rendering still works (config + Jinja2 template -> CLI commands).
- [ ] `range()` with values <= 100,000 still renders.
- [ ] `range()` with values > 100,000 is blocked by the sandbox.
- [ ] CI Gitleaks and build-stlite steps still receive their token.
- [ ] No other workflow step depended on `GITHUB_TOKEN` in `$GITHUB_ENV`.

Refs #325. Replaces #322.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTMLrVY67mL6otnS5cWKxo)_