### PR TITLE
feat: add repo-owned superpowers SessionStart hook (#333)

### DIFF
--- a/.claude/hooks/superpowers-session-start.sh
+++ b/.claude/hooks/superpowers-session-start.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Repo-owned SessionStart hook for the superpowers skill collection.
+#
+# Purpose: inject the "using-superpowers" skill at session start so the agent
+# knows, from its first turn, to discover and use the skills under
+# .claude/skills/ via the Skill tool.
+#
+# Why this exists instead of the upstream superpowers hook: superpowers ships
+# as a Claude Code *plugin* whose hook reads "${CLAUDE_PLUGIN_ROOT}/skills/..."
+# and relies on CLAUDE_PLUGIN_ROOT being set. Here the skills are deployed by
+# APM under .claude/skills/ and CLAUDE_PLUGIN_ROOT is not set, so we read the
+# committed skill file directly and emit Claude Code's SessionStart format.
+set -euo pipefail
+
+root="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+skill="${root}/.claude/skills/using-superpowers/SKILL.md"
+
+# If the skill is absent (superpowers not installed), inject nothing.
+[ -f "${skill}" ] || exit 0
+
+python3 - "${skill}" <<'PY'
+import json
+import sys
+
+content = open(sys.argv[1], encoding="utf-8").read()
+context = (
+    "<EXTREMELY_IMPORTANT>\n"
+    "You have superpowers.\n\n"
+    "Below is the full content of your 'using-superpowers' skill - your "
+    "introduction to using skills. For all other skills, use the Skill "
+    "tool:\n\n"
+    f"{content}\n"
+    "</EXTREMELY_IMPORTANT>"
+)
+print(
+    json.dumps(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": context,
+            }
+        }
+    )
+)
+PY

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/superpowers-session-start.sh",
+            "async": false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -189,8 +189,8 @@ docs/s-exp
 # APM dependencies
 apm_modules/
 
-# APM-regenerated local Claude state (the superpowers skills under
-# .claude/skills/ are committed; these are local/regenerable artifacts).
+# APM-regenerated local Claude state. The superpowers skills under
+# .claude/skills/, the repo-owned .claude/hooks/, and .claude/settings.json
+# are committed; the entries below are local/regenerable artifacts.
 .claude/rules/
-.claude/settings.json
 .claude/settings.local.json


### PR DESCRIPTION
## Summary

Closes #333.

Makes the superpowers SessionStart context injection actually work, using a small repo-owned hook instead of the upstream plugin hook.

## Why

superpowers ships its SessionStart hook for the Claude Code *plugin* model: it reads `${CLAUDE_PLUGIN_ROOT}/skills/using-superpowers/SKILL.md` and needs `CLAUDE_PLUGIN_ROOT`. When superpowers is installed via APM (#329) that does not hold:

- APM (0.12.1 and 0.16.1) does not deploy a working hook. 0.16.1 writes `.claude/hooks/superpowers/hooks/run-hook.cmd` but never deploys the `session-start` script it `exec`s, so the chain fails with `exit 127`.
- The upstream script reads skills under the plugin root and needs `CLAUDE_PLUGIN_ROOT`; APM puts skills under `.claude/skills/` and sets no such env var.

## Changes

- `.claude/hooks/superpowers-session-start.sh` - reads the committed `.claude/skills/using-superpowers/SKILL.md` and emits Claude Code's `hookSpecificOutput.additionalContext` JSON (bash + python3 for robust escaping). Graceful no-op (exit 0) when the skill is absent.
- `.claude/settings.json` - registers the `SessionStart` hook (matcher `startup|clear|compact`).
- `.gitignore` - stop ignoring `.claude/settings.json` (now committed); keep `.claude/rules/` and `.claude/settings.local.json` ignored.

No third-party code is edited or vendored. No APM re-install or recompile, so `CLAUDE.md`, `apm.yml`, and `apm.lock.yaml` are unchanged.

## Verification

- Running the hook from the project root exits 0 and emits valid JSON with `hookEventName=SessionStart` and `additionalContext` containing the using-superpowers skill content (5613 chars).
- With the skill absent (`CLAUDE_PROJECT_DIR` elsewhere) the hook is a graceful no-op (exit 0, no output), so it never disrupts a session.
- `.claude/settings.json` is valid JSON; `typos` v1.32.0 reports zero errors on the new files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfnftZKfUwRzb4mbrVGbR1)_