### PR TITLE
test(e2e): fix Streamlit 1.58 filename truncation and sidebar collapse assertions (#346)

### DIFF
--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -459,11 +459,37 @@ class StreamlitTestHelper:
 
         self.wait_for_ui_stabilization()
 
-        config_text: Final[str] = config_upload_container.inner_text()
-        assert config_file in config_text, f"Config file name not displayed.\nExpected: {config_file}\nActual text: {config_text}"
+        config_name: Final[str] = self.get_uploaded_file_name(config_upload_container)
+        assert config_file == config_name, f"Config file name not displayed.\nExpected: {config_file}\nActual: {config_name}"
 
-        jinja_text = jinja_upload_container.inner_text()
-        assert template_file in jinja_text, f"Template file name not displayed.\nExpected: {template_file}\nActual text: {jinja_text}"
+        jinja_name: Final[str] = self.get_uploaded_file_name(jinja_upload_container)
+        assert template_file == jinja_name, f"Template file name not displayed.\nExpected: {template_file}\nActual: {jinja_name}"
+
+    def get_uploaded_file_name(self, upload_container: Locator) -> str:
+        """アップロード済みファイルチップから完全なファイル名を取得.
+
+        Args:
+            upload_container: ファイルアップローダー要素のLocator
+
+        Returns:
+            str: アップロードされたファイルの完全な名前
+
+        Raises:
+            AssertionError: ファイル名チップまたはtitle属性が存在しない場合
+
+        Note:
+            Streamlit 1.58のファイルアップローダーは表示テキストを中央省略する
+            (例: ``cisco_template.jinja2`` -> ``cisco...plate.jinja2``)。
+            このため可視テキストではなく、完全なファイル名を保持する
+            ``[data-testid='stFileChipName']`` の ``title`` 属性から読み取る。
+        """
+        name_chip: Final[Locator] = upload_container.locator("[data-testid='stFileChipName']").first
+        expect(name_chip).to_be_visible()
+
+        file_name: Final[Optional[str]] = name_chip.get_attribute("title")
+        assert file_name is not None, "Uploaded file chip is missing its title attribute"
+
+        return file_name
 
     def get_display_button(self, display_format: str) -> Locator:
         """表示形式に応じたボタンを取得.

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -212,10 +212,18 @@ def test_ui_responsive_design(page: Page) -> None:
     page.reload()
     page.wait_for_load_state("networkidle")
 
-    # モバイルビューでの表示を確認
-    # ハンバーガーメニューが表示されることを確認
-    hamburger_button: Final[Locator] = page.locator("div[data-testid='stSidebarCollapsedControl']").first
-    expect(hamburger_button).to_be_visible()
+    # モバイルビュー(<= breakpoints.sm = 576px)ではサイドバーの折りたたみボタンが
+    # 常時表示される。アプリは initial_sidebar_state="expanded" のため、
+    # Streamlit 1.58 はビューポート幅では自動折りたたみせず、サイドバーは開いたまま。
+    # そこで折りたたみボタンを押してサイドバーを閉じ、レスポンシブな
+    # 折りたたみ/展開コントロールが機能することを確認する。
+    collapse_button: Final[Locator] = page.locator("div[data-testid='stSidebarCollapseButton']").first
+    expect(collapse_button).to_be_visible()
+    collapse_button.click()
+
+    # サイドバーが折りたたまれると、ヘッダーに展開(ハンバーガー)ボタンが表示される
+    expand_button: Final[Locator] = page.locator("button[data-testid='stExpandSidebarButton']").first
+    expect(expand_button).to_be_visible()
 
     # デスクトップビューに戻す
     page.set_viewport_size({"width": 1280, "height": 720})


### PR DESCRIPTION
## Summary

Fixes the three E2E tests that fail deterministically under Streamlit 1.58
(tracked in #346 after the `95d038c` repair on #344 proved insufficient):

- `test_command_generation_parametrized_in_tab1[...to_file]`
- `test_command_generation_parametrized_in_tab1[...to_markdown]`
- `test_ui_responsive_design`

Both root causes were confirmed by inspecting the installed Streamlit 1.58
frontend assets (`.venv/.../streamlit/static`), not guessed.

## Root cause A -- filename middle-truncation (2 tests)

The 1.58 file-uploader chip renders the visible name through a JS
middle-truncation helper (`Zt`, threshold 20 chars), inserting a literal
`...`. So `cisco_template.jinja2` (21 chars) displays as
`cisco...plate.jinja2` and the `inner_text()` substring assertion failed,
while `cisco_config.toml` (17 chars) fit and passed -- exactly the split
reported in #346.

The element `[data-testid='stFileChipName']` keeps the **full** name in its
`title` attribute (`title: e.name`, `children: Zt(e.name)`). The new
`get_uploaded_file_name()` helper reads `title`, so the assertion is exact
and robust against future chip-width / threshold changes (the issue's
direction A; avoids re-tuning fixture name length).

## Root cause B -- collapsed-sidebar selector (1 test)

In 1.58 the expand control is `[data-testid='stExpandSidebarButton']`,
rendered by the header only when `hasSidebar && !isSidebarOpen`. The app sets
`initial_sidebar_state="expanded"` and 1.58 has no viewport-width auto-collapse,
so at 375px the sidebar stayed **open** and the expand button never rendered --
which is why both the old `stSidebarCollapsedControl` and the `95d038c`
`stExpandSidebarButton` selectors timed out.

The test now clicks the collapse button `[data-testid='stSidebarCollapseButton']`
(force-visible at `@media (max-width: breakpoints.sm = 576px)`) to collapse the
open sidebar, then asserts `stExpandSidebarButton` becomes visible. This
deterministically exercises the responsive collapse/expand controls.

## Verification

- `ruff check`, `ruff format --check`, and `mypy` pass on both changed files.
- Per #346's verification constraint, Playwright browser install is
  egress-blocked in the dev container, so the E2E behavior is proven by the
  CI matrix run on this PR -- not a local run.

Closes #346

https://claude.ai/code/session_01WGJVG7o8J86i2om8GMQYw3

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGJVG7o8J86i2om8GMQYw3)_