### PR TITLE
ci: enforce pyproject-fmt canonical form and normalize pyproject.toml

### DIFF
--- a/.github/workflows/reusable-test-and-build.yml
+++ b/.github/workflows/reusable-test-and-build.yml
@@ -310,6 +310,10 @@ jobs:
         run: |
           uv run ruff check . -v
 
+      - name: Check pyproject.toml formatting
+        run: |
+          uv run pre-commit run pyproject-fmt --all-files
+
       - name: Run Vulture
         run: |
           uv run vulture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,63 +2,64 @@
 name = "command-ghostwriter"
 version = "0.0.0"
 requires-python = ">=3.11,<4.0"
+classifiers = [
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
 dependencies = [
-  "streamlit>=1.47.0,<2",
+  "chardet>=5.2,<6",
   "jinja2>=3.1.6,<4",
-  "pyyaml>=6.0.1,<7",
-  "chardet>=5.2.0,<6",
-  "python-box>=7.2.0,<8",
+  "markupsafe>=3.0.2,<4",
   # Pinned to the 2.11 series for migrate-not-upgrade parity: tests/unit/test_document_render.py
   # asserts pydantic's error-doc URL, which embeds the minor version (errors.pydantic.dev/2.11/).
   # Lift the <2.12 ceiling in a dedicated upgrade PR that also updates that fixture.
   "pydantic>=2.11.7,<2.12",
+  "python-box>=7.2,<8",
+  "pyyaml>=6.0.1,<7",
+  "streamlit>=1.47,<2",
   "toml>=0.10.2,<0.11",
-  "markupsafe>=3.0.2,<4",
 ]
 
 [dependency-groups]
 dev = [
-  "mypy>=1.17.0,<2",
-  "pytest>=9.0.3,<10",
-  "pytest-cov>=6.2.1,<7",
-  "types-toml>=0.10.8.20240310,<0.11",
-  "pre-commit>=4.2.0,<5",
-  "lizard>=1.17.31,<2",
-  "types-pyyaml>=6.0.12.20250516,<7",
-  "pydeps>=3.0.1,<4",
-  "pytest-playwright>=0.7.0,<0.8",
-  "ruff>=0.12.3,<0.13",
-  "pandas-stubs>=2.3.0.250703,<3",
-  "mock>=5.2.0,<6",
-  "gitpython>=3.1.44,<4",
-  "packaging>=25.0,<26",
-  "pytest-xdist>=3.8.0,<4",
-  "pytest-mock>=3.14.1,<4",
-  "psutil>=7.0.0,<8",
-  "pytest-randomly>=3.16.0,<4",
-  "pytest-benchmark==5.1.0",
-  "pytest-clarity>=1.0.1,<2",
-  "pygal>=3.0.5,<4",
-  "pytest-timeout>=2.4.0,<3",
-  "pyre-check>=0.9.25,<0.10",
-  "pytest-item-dict>=1.1.2,<2",
-  "pytest-xml>=0.1.1,<0.2",
   "data-to-xml>=1.0.9,<2",
+  "gitpython>=3.1.44,<4",
+  "lizard>=1.17.31,<2",
+  "mock>=5.2,<6",
+  "mypy>=1.17,<2",
+  "packaging>=25,<26",
+  "pandas-stubs>=2.3.0.250703,<3",
+  "pre-commit>=4.2,<5",
+  "psutil>=7,<8",
+  "pydeps>=3.0.1,<4",
+  "pygal>=3.0.5,<4",
+  "pyre-check>=0.9.25,<0.10",
+  "pytest>=9.0.3,<10",
+  "pytest-benchmark==5.1",
+  "pytest-clarity>=1.0.1,<2",
+  "pytest-cov>=6.2.1,<7",
+  "pytest-item-dict>=1.1.2,<2",
+  "pytest-mock>=3.14.1,<4",
+  "pytest-playwright>=0.7,<0.8",
+  "pytest-randomly>=3.16,<4",
+  "pytest-rerunfailures>=15,<16",
+  "pytest-timeout>=2.4,<3",
+  "pytest-xdist>=3.8,<4",
+  "pytest-xml>=0.1.1,<0.2",
+  "ruff>=0.12.3,<0.13",
+  "types-psutil>=7.0.0.20250601,<8",
+  "types-pyyaml>=6.0.12.20250516,<7",
+  "types-requests>=2.32.4.20250611,<3",
+  "types-toml>=0.10.8.20240310,<0.11",
   "vulture>=2.14,<3",
   "yamllint>=1.37.1,<2",
-  "types-psutil>=7.0.0.20250601,<8",
-  "types-requests>=2.32.4.20250611,<3",
-  "pytest-rerunfailures>=15,<16",
 ]
 # devcontainer 専用の対話デバッガ。CI では同期しない（uv sync --group local で追加）。
 local = [
   "pudb>=2025.1,<2026",
 ]
-
-[tool.uv]
-package = false
-# flake.nix がこの値を読む。実装時点の本環境 uv 0.8.17 を初期 pin とする。
-required-version = "==0.8.17"
 
 [tool.ruff]
 target-version = "py312"
@@ -212,6 +213,11 @@ python_version = "3.12"
 warn_return_any = false
 warn_unused_configs = true
 warn_unreachable = true
+
+[tool.uv]
+package = false
+# flake.nix がこの値を読む。実装時点の本環境 uv 0.8.17 を初期 pin とする。
+required-version = "==0.8.17"
 
 [tool.benchmark]
 min_time = 0.1


### PR DESCRIPTION
Closes #372 (follow-up to retrospective #371, repair 1 of #370)

## Why

`main`'s `pyproject.toml` was not in `pyproject-fmt` canonical form, yet CI did not run `pyproject-fmt` (the quality gate runs only mypy + ruff + vulture). The hook is configured in `.pre-commit-config.yaml` but is local-only, so it rewrote the entire file on any `pyproject.toml` edit. In #370 a 6-line `addopts` change pulled in ~39/-33 lines of dependency reordering and version-spec normalization, which also made dependency-review flag 3 packages with "unknown license" and required a manual restore-and-amend.

## What

- Normalize `pyproject.toml` via the pinned `pyproject-fmt` pre-commit hook (tox-dev/pyproject-fmt v2.5.1).
- Add a `Check pyproject.toml formatting` step to the `guard-python-code-quality` job that runs the same pinned hook (`uv run pre-commit run pyproject-fmt --all-files`). Using the pre-commit hook keeps a single source of truth for the pinned version and adds no new dependency (`pre-commit` is already a dev dependency).

## Result

The baseline stays canonical, so future minimal edits to `pyproject.toml` produce minimal diffs with no manual restore-and-amend, and dependency-review has nothing spurious to scan.

## Expected one-time dependency-review warning

This PR is itself the normalization, so it changes the dependency version specs (e.g. `1.47.0` -> `1.47`) once. dependency-review therefore re-scans chardet / python-box / streamlit and emits a non-blocking "unknown license" warning (0 vulnerabilities, 0 incompatible licenses). This is the expected one-time cost of normalizing; after merge the baseline is canonical and future PRs will not touch these specs unless intended.

## Verification

- `uv run pre-commit run pyproject-fmt --all-files` passes on the normalized file (idempotent; verified locally).
- The egress needed by the new step is already allowed on `guard-python-code-quality`: `github.com` (EP_GITHUB_CORE) to clone the hook repo, `pypi.org` + `files.pythonhosted.org` (EP_PYTHON) to install pyproject-fmt + tox.
- CI green confirms the step runs in the hardened-runner environment.