### PR TITLE
ci: configure git identity at session start to avoid Unverified commits

### DIFF
--- a/.claude/hooks/git-identity-session-start.sh
+++ b/.claude/hooks/git-identity-session-start.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Repo-owned SessionStart hook: ensure commits carry a verified identity.
+#
+# The remote Claude Code environment clones the repo fresh per session with no
+# committer identity configured, so the first commit is flagged Unverified
+# (committer email != noreply@anthropic.com). Configure the identity here, at
+# session start, before any commit can be made. See retrospective #371 / #373.
+#
+# Idempotent: sets repo-local git config on every session-start event.
+set -euo pipefail
+
+root="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+# Only act inside a git work tree; do nothing (success) otherwise.
+git -C "${root}" rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+git -C "${root}" config user.email "noreply@anthropic.com"
+git -C "${root}" config user.name "Claude"
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,16 @@
             "async": false
           }
         ]
+      },
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/git-identity-session-start.sh",
+            "async": false
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
Closes #373 (follow-up to retrospective #371, repair 2 of #370)

## Why

The remote Claude Code environment clones the repo fresh per session with no committer identity configured, so the first commit is flagged Unverified (committer email != `noreply@anthropic.com`). In #370 this required a manual repair: `git config ...` then `git commit --amend --reset-author`.

## What

- Add a repo-owned SessionStart hook `.claude/hooks/git-identity-session-start.sh` that sets repo-local git identity (`noreply@anthropic.com` / `Claude`) before any commit can be made.
- Register it in `.claude/settings.json` alongside the existing superpowers SessionStart hook.

The script guards against non-git directories (exits 0 quietly) and is idempotent (safe to run on every session-start event).

## Result

The first commit of every session already carries the verified identity, so no amend/reset-author repair is needed.

## Verification (local)

CI cannot exercise a Claude SessionStart hook, so verification is local:

- `python3 -m json.tool .claude/settings.json` -> valid JSON.
- `bash -n .claude/hooks/git-identity-session-start.sh` -> syntax OK.
- Running the hook against a fresh temp repo sets `user.email=noreply@anthropic.com` and `user.name=Claude` (repo-local, overriding any global).
- Running it in a non-git directory exits 0 with no error (guard works).

---
_Generated by [Claude Code](https://claude.ai/code/session_0173cUF33ZhCBywudTqamivV)_