### PR TITLE
Frontend P1a: Pyodide worker bring-up + render-parity smoke (#398)

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -1,0 +1,103 @@
+# ============================================================
+# Workflow Information: web-ci.yml
+# ============================================================
+#
+# 目的 (Purpose):
+# ---------------
+# web/ フロントエンドのテストスイートを CI に組み込む。
+#  - web-test: npm ci (postinstall で Pyodide ホイールをベンダリング)、
+#    npm run build、npx vitest run (Pyodide キーストーンゲート) を実行する。
+#    このジョブは PR ごとに必須ブロッキングゲートとして機能する。
+#  - web-e2e: Playwright ブラウザ E2E テストを実行する (現時点では非ブロッキング)。
+#
+# 影響範囲 (Scope of Impact):
+# ---------------------------
+# - web/**、features/**、または本ワークフロー自体が変更された PR・push で動作する。
+# - リポジトリへの書き込みは行わない (contents: read)。
+#
+# セキュリティ (Security):
+# ------------------------
+# - step-security/harden-runner でランナーを強化。
+# - egress-policy: audit を使用 (postinstall が GitHub Releases + PyPI へのアクセスを必要とするため)。
+#
+# 関連 (Reference):
+# -----------------
+# - Issue #398
+# ============================================================
+---
+name: Web CI
+
+on:
+  pull_request:
+    paths:
+      - "web/**"
+      - "features/**"
+      - ".github/workflows/web-ci.yml"
+  push:
+    branches:
+      - "claude/**"
+    paths:
+      - "web/**"
+      - "features/**"
+      - ".github/workflows/web-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  web-test:
+    name: Web Vitest (Pyodide keystone)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Node
+        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: Install (vendors Pyodide wheels via postinstall) and build
+        working-directory: web
+        run: |
+          npm ci
+          npm run build
+      - name: Vitest keystone (features/ render parity in Pyodide)
+        working-directory: web
+        run: npx vitest run
+
+  web-e2e:
+    name: Web Playwright e2e (browser proof, non-blocking)
+    runs-on: ubuntu-latest
+    # Non-blocking for now: the Playwright browser CDN (cdn.playwright.dev) may be
+    # egress-restricted. Promote to a hard gate once that endpoint is confirmed
+    # reachable/allowlisted in CI. Refs #398.
+    continue-on-error: true
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Node
+        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: Install and build
+        working-directory: web
+        run: |
+          npm ci
+          npm run build
+      - name: Install chromium
+        working-directory: web
+        run: npx playwright install --with-deps chromium
+      - name: Playwright e2e
+        working-directory: web
+        run: npx playwright test

--- a/docs/superpowers/plans/2026-06-12-frontend-p1a-pyodide-bringup.md
+++ b/docs/superpowers/plans/2026-06-12-frontend-p1a-pyodide-bringup.md
@@ -1,0 +1,906 @@
+# Frontend P1a: Pyodide Worker Bring-up + Render-Parity Smoke Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove that the tested Python core (`features/`) runs unmodified inside a self-hosted browser Pyodide runtime and produces byte-identical rendered output to CPython, behind a thin `postMessage` worker contract with a minimal React harness.
+
+**Architecture:** Greenfield Vite + React + TypeScript app under `web/`. A Web Worker boots a **self-hosted** Pyodide (vendored from the npm `pyodide` package — the public jsdelivr CDN is blocked by this environment's network policy, confirmed 403), mounts the repo's `features/*.py` into the Pyodide FS via Vite `?raw` glob (single source of truth, no copy/duplication), installs the five third-party deps `features/` actually imports, and exposes a `init`/`generate`/`ready`/`error` contract. The UI thread wraps two editor strings into the worker request and renders the result. The keystone verification — `features/` running in Pyodide and matching CPython render output — runs in **Vitest on Node** (Pyodide runs under Node, so no browser is required for the primary gate); a Playwright e2e proves the same in a real browser build.
+
+**Tech Stack:** Vite 5, React 18, TypeScript 5, Vitest 2, `pyodide` (npm, self-hosted), Playwright (e2e, browser-dependent). Python deps loaded into Pyodide via micropip: `jinja2`, `pyyaml`, `pydantic`, `chardet` (`markupsafe` auto-resolves as a jinja2 dependency).
+
+**Scope boundary (what this plan deliberately defers):** CodeMirror 6 editors, drag-and-drop, settings drawer (旧tab3), samples menu (旧tab4), how-to modal (旧tab5), markdown/config-debug preview modes, client-side download, i18n catalog, and Vercel deployment are all **out of scope for P1a** and belong to later sub-plans (P1b/P1c) written after this bring-up is proven. P1a uses two plain `<textarea>`s and a `<pre>` output purely to exercise the worker end-to-end.
+
+**Verification honesty (standards §1, spec §テスト戦略):**
+- Primary gate (Tasks 1–3): Vitest on Node — runnable in this environment now (npm 200, PyPI 200). No browser needed.
+- Secondary gate (Task 4): Playwright e2e — requires `npx playwright install chromium` (network-dependent). If chromium cannot be installed/run in the execution environment, mark the e2e **"未検証 (ローカル)"** explicitly and rely on CI to run it; never substitute an indirect signal for the browser proof.
+
+---
+
+## File Structure
+
+All new files live under `web/` (sibling to `features/`). The existing root `package.json` (Electron/stlite) is left untouched; `web/` has its own `package.json`.
+
+| Path | Responsibility |
+| --- | --- |
+| `web/package.json` | Frontend package manifest, scripts, deps (own npm root, isolated from root Electron package). |
+| `web/vite.config.ts` | Vite build config: React plugin, `server.fs.allow` to read `../features`, copy vendored Pyodide assets to `public/pyodide/`, worker format. |
+| `web/vitest.config.ts` | Vitest config: Node environment for worker/Pyodide tests, jsdom for component test. |
+| `web/tsconfig.json` | TypeScript config. |
+| `web/index.html` | Vite entry HTML. |
+| `web/src/main.tsx` | React mount point. |
+| `web/src/App.tsx` | Minimal harness: two `<textarea>`s + button + `<pre>` output + error banner; debounced worker calls. |
+| `web/src/worker/features-sources.ts` | Vite `?raw` glob importing `../../../features/**/*.py` into a `{ relPath: source }` map (single source of truth). |
+| `web/src/worker/pyodide-runtime.ts` | Environment-agnostic bootstrap + generate logic (takes a `loadPyodide` fn + indexURL); reusable by both the browser worker and the Node test. |
+| `web/src/worker/generate.worker.ts` | Browser Web Worker: wires `pyodide-runtime` to `postMessage` (`init`/`generate`/`ready`/`error`). |
+| `web/src/worker/types.ts` | Shared TS types for the worker message contract and settings. |
+| `web/src/worker/pyodide-runtime.node.test.ts` | **Keystone** Vitest (Node): boots Pyodide, runs `features/` AppCore on a known CSV+Jinja fixture, asserts byte-identical render parity with CPython. |
+| `web/src/worker/contract.test.ts` | Vitest: verifies the `init`/`generate`/`ready`/`error` message-shape handling of `pyodide-runtime` generate wrapper. |
+| `web/src/App.test.tsx` | Vitest (jsdom): component test with a mocked worker — debounce, output render, error banner. |
+| `web/e2e/render-parity.spec.ts` | Playwright e2e: load built site, type fixture, assert rendered output (browser proof). |
+| `web/playwright.config.ts` | Playwright config pointing at `vite preview`. |
+| `web/.gitignore` | Ignore `node_modules`, `dist`, `public/pyodide` (vendored at build), Playwright artifacts. |
+
+**Render delivery into Pyodide (decision, no placeholder):** `features/*.py` are imported as raw strings at build time via `import.meta.glob('../../../features/**/*.py', { query: '?raw', eager: true, import: 'default' })` and written into the Pyodide FS under `/features/...` at worker init, then `import features` after `sys.path.insert(0, "/")`. This keeps `features/` as the **single source of truth** — no tarball, no copy step, no duplication. Dev mode requires `server.fs.allow: ['..']` so Vite can read the parent `features/` dir; build inlines the strings.
+
+**Pyodide vendoring (decision):** Pyodide core + its bundled package distribution are self-hosted from `node_modules/pyodide` — the browser worker loads from `/pyodide/` (copied to `public/pyodide/` by a Vite plugin at build), the Node test loads from `node_modules/pyodide` directly. No request ever goes to jsdelivr (blocked). Pure-Python wheels not in the bundled distribution are fetched by micropip from PyPI (reachable, 200).
+
+---
+
+### Task 0: Scaffold `web/` and vendor Pyodide
+
+**Files:**
+- Create: `web/package.json`, `web/tsconfig.json`, `web/vite.config.ts`, `web/index.html`, `web/src/main.tsx`, `web/src/App.tsx` (stub), `web/.gitignore`
+
+- [ ] **Step 1: Create `web/package.json`**
+
+```json
+{
+  "name": "command-ghostwriter-web",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --port 4173 --strictPort",
+    "test": "vitest run",
+    "e2e": "playwright test"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.56.1",
+    "@testing-library/react": "^16.0.1",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^25.0.1",
+    "pyodide": "^0.26.4",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.11",
+    "vitest": "^2.1.8"
+  }
+}
+```
+
+- [ ] **Step 2: Create `web/tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client", "vitest/globals"]
+  },
+  "include": ["src", "e2e"]
+}
+```
+
+- [ ] **Step 3: Create `web/vite.config.ts`**
+
+```ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { createRequire } from "node:module";
+import { cpSync, existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+const pyodideDir = dirname(require.resolve("pyodide"));
+
+// Self-host the vendored Pyodide distribution (jsdelivr CDN is blocked).
+function vendorPyodide() {
+  return {
+    name: "vendor-pyodide",
+    buildStart() {
+      const dest = resolve(__dirname, "public/pyodide");
+      if (!existsSync(dest)) {
+        cpSync(pyodideDir, dest, { recursive: true });
+      }
+    },
+  };
+}
+
+export default defineConfig({
+  plugins: [react(), vendorPyodide()],
+  server: {
+    // Allow Vite to read ../features (single source of truth for the Python core).
+    fs: { allow: [".."] },
+  },
+  worker: { format: "es" },
+});
+```
+
+- [ ] **Step 4: Create `web/index.html`**
+
+```html
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Command Ghostwriter</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+- [ ] **Step 5: Create `web/src/main.tsx`**
+
+```tsx
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);
+```
+
+- [ ] **Step 6: Create `web/src/App.tsx` (stub, fleshed out in Task 3)**
+
+```tsx
+export function App() {
+  return <main>Command Ghostwriter</main>;
+}
+```
+
+- [ ] **Step 7: Create `web/.gitignore`**
+
+```gitignore
+node_modules
+dist
+dist-ssr
+public/pyodide
+test-results
+playwright-report
+*.local
+```
+
+- [ ] **Step 8: Install deps and verify the scaffold builds**
+
+Run:
+```bash
+cd web && npm install && npm run build
+```
+Expected: `npm install` resolves (network 200), `tsc -b` passes, `vite build` emits `dist/` with no errors. The `vendor-pyodide` plugin copies `node_modules/pyodide` into `web/public/pyodide` (so `dist/pyodide/` is present).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/package.json web/package-lock.json web/tsconfig.json web/vite.config.ts web/index.html web/src/main.tsx web/src/App.tsx web/.gitignore
+git commit -m "feat(web): scaffold Vite+React+TS shell with self-hosted Pyodide (#<ISSUE>)"
+```
+
+---
+
+### Task 1: Pyodide runtime bootstrap + keystone render-parity test (Node)
+
+This is the highest-risk, highest-value task: it proves `features/` runs in Pyodide with identical output to CPython, using Vitest on Node (no browser).
+
+**Files:**
+- Create: `web/src/worker/types.ts`, `web/src/worker/features-sources.ts`, `web/src/worker/pyodide-runtime.ts`
+- Test: `web/src/worker/pyodide-runtime.node.test.ts`
+- Create: `web/vitest.config.ts`
+
+- [ ] **Step 1: Create `web/vitest.config.ts`**
+
+```ts
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: { fs: { allow: [".."] } },
+  test: {
+    globals: true,
+    // Node by default (Pyodide-in-Node keystone test); the component test opts into jsdom per-file.
+    environment: "node",
+    testTimeout: 120_000, // Pyodide boot + micropip install is slow on first run.
+    hookTimeout: 120_000,
+  },
+});
+```
+
+- [ ] **Step 2: Create `web/src/worker/types.ts`**
+
+```ts
+export interface GenerateSettings {
+  csvRowsName: string;
+  enableAutoTranscoding: boolean;
+  enableFillNan: boolean;
+  fillNanWith: string;
+  formatType: number; // 0..4
+  isStrictUndefined: boolean;
+}
+
+export interface GenerateRequest {
+  configText: string;
+  configName: string; // e.g. "config.csv" — extension drives parser selection
+  templateText: string;
+  templateName: string; // e.g. "template.j2"
+  settings: GenerateSettings;
+}
+
+export interface GenerateResult {
+  output: string | null;
+  configError: string | null;
+  templateError: string | null;
+}
+
+export const DEFAULT_SETTINGS: GenerateSettings = {
+  csvRowsName: "csv_rows",
+  enableAutoTranscoding: true,
+  enableFillNan: true,
+  fillNanWith: "#",
+  formatType: 0,
+  isStrictUndefined: true,
+};
+
+// Browser worker message contract.
+export type WorkerInbound =
+  | { kind: "init" }
+  | { kind: "generate"; id: number; request: GenerateRequest };
+
+export type WorkerOutbound =
+  | { kind: "ready" }
+  | { kind: "result"; id: number; result: GenerateResult }
+  | { kind: "error"; id: number | null; message: string };
+```
+
+- [ ] **Step 3: Create `web/src/worker/features-sources.ts`**
+
+```ts
+// Import every features/*.py as a raw string at build time (single source of truth).
+// Keys look like "../../../features/core.py"; we normalize to "features/core.py".
+const raw = import.meta.glob("../../../features/**/*.py", {
+  query: "?raw",
+  eager: true,
+  import: "default",
+}) as Record<string, string>;
+
+export const FEATURES_SOURCES: Record<string, string> = Object.fromEntries(
+  Object.entries(raw).map(([key, source]) => {
+    const idx = key.lastIndexOf("features/");
+    return [key.slice(idx), source];
+  }),
+);
+```
+
+- [ ] **Step 4: Create `web/src/worker/pyodide-runtime.ts`**
+
+```ts
+import type { GenerateRequest, GenerateResult } from "./types";
+import { FEATURES_SOURCES } from "./features-sources";
+
+// Minimal structural type for the bits of the Pyodide API we use.
+export interface PyodideLike {
+  FS: {
+    mkdirTree(path: string): void;
+    writeFile(path: string, data: string, opts?: { encoding: string }): void;
+  };
+  loadPackage(names: string[]): Promise<void>;
+  pyimport(name: string): { install(reqs: string[]): Promise<void> };
+  runPythonAsync(code: string): Promise<unknown>;
+  globals: { get(name: string): unknown };
+}
+
+export type LoadPyodideFn = (opts: { indexURL: string }) => Promise<PyodideLike>;
+
+// Third-party packages that features/ actually imports.
+// markupsafe resolves automatically as a jinja2 dependency.
+const PY_DEPS = ["jinja2", "pyyaml", "pydantic", "chardet"];
+
+export async function bootstrapRuntime(
+  loadPyodide: LoadPyodideFn,
+  indexURL: string,
+): Promise<PyodideLike> {
+  const pyodide = await loadPyodide({ indexURL });
+
+  // micropip resolves from the bundled Pyodide distribution first, PyPI otherwise.
+  await pyodide.loadPackage(["micropip"]);
+  const micropip = pyodide.pyimport("micropip");
+  await micropip.install(PY_DEPS);
+
+  // Mount features/ into the Pyodide FS (single source of truth, written verbatim).
+  for (const [relPath, source] of Object.entries(FEATURES_SOURCES)) {
+    const dir = relPath.slice(0, relPath.lastIndexOf("/"));
+    pyodide.FS.mkdirTree("/" + dir);
+    pyodide.FS.writeFile("/" + relPath, source, { encoding: "utf8" });
+  }
+
+  await pyodide.runPythonAsync(`
+import sys
+if "/" not in sys.path:
+    sys.path.insert(0, "/")
+import features.core  # fail loudly here if a dep or import is missing
+`);
+
+  return pyodide;
+}
+
+export async function generate(
+  pyodide: PyodideLike,
+  request: GenerateRequest,
+): Promise<GenerateResult> {
+  // Pass the request as a JSON string to avoid proxy lifetime concerns.
+  const payload = JSON.stringify(request);
+  const code = `
+import json
+from io import BytesIO
+from features.core import AppCore
+
+req = json.loads(${"`"}${"${payload}"}${"`"})
+s = req["settings"]
+
+config_file = BytesIO(req["configText"].encode("utf-8"))
+config_file.name = req["configName"]
+template_file = BytesIO(req["templateText"].encode("utf-8"))
+template_file.name = req["templateName"]
+
+core = AppCore("設定定義ファイルの読み込みに失敗", "Jinjaテンプレートの読み込みに失敗")
+core.load_config_file(
+    config_file,
+    s["csvRowsName"],
+    s["enableAutoTranscoding"],
+    s["enableFillNan"],
+    s["fillNanWith"],
+).load_template_file(
+    template_file,
+    s["enableAutoTranscoding"],
+).apply(
+    s["formatType"],
+    s["isStrictUndefined"],
+)
+
+json.dumps({
+    "output": core.formatted_text,
+    "configError": core.config_error_message,
+    "templateError": core.template_error_message,
+})
+`;
+  const resultJson = (await pyodide.runPythonAsync(code)) as string;
+  return JSON.parse(resultJson) as GenerateResult;
+}
+```
+
+> NOTE for the implementer: the template-literal interpolation of `payload` above must produce a Python triple-backtick-free string. Use `json.dumps`/`json.loads` round-tripping via a Python raw string assigned from a JS template literal. Concretely, build the Python `req = json.loads(<js-injected JSON string literal>)` by passing the JSON through `JSON.stringify` once more so it becomes a valid Python string literal, e.g. `const pyLiteral = JSON.stringify(payload);` then embed `json.loads(${pyLiteral})`. Replace the fragile inline form with: `` const code = \`...\nreq = json.loads(${JSON.stringify(payload)})\n...\`; ``. This guarantees no quoting/backtick injection.
+
+- [ ] **Step 5: Write the failing keystone test `web/src/worker/pyodide-runtime.node.test.ts`**
+
+```ts
+import { describe, it, expect, beforeAll } from "vitest";
+import { createRequire } from "node:module";
+import { dirname } from "node:path";
+import { loadPyodide } from "pyodide";
+import { bootstrapRuntime, generate, type PyodideLike } from "./pyodide-runtime";
+import { DEFAULT_SETTINGS } from "./types";
+
+const require = createRequire(import.meta.url);
+const indexURL = dirname(require.resolve("pyodide"));
+
+describe("features/ render parity in Pyodide (Node)", () => {
+  let pyodide: PyodideLike;
+
+  beforeAll(async () => {
+    pyodide = await bootstrapRuntime(
+      loadPyodide as unknown as Parameters<typeof bootstrapRuntime>[0],
+      indexURL,
+    );
+  }, 120_000);
+
+  it("renders a CSV+Jinja fixture byte-identically to the CPython golden", async () => {
+    // Mirrors tests/unit/test_config_parser.py::test_csv_render_layer_parity:
+    // ints stay ints (1/3/100/300), "N/A" stays the literal string (#396 na-strings),
+    // and the rendered output is exactly "1:100\n2:N/A\n3:300\n".
+    const result = await generate(pyodide, {
+      configText: "id,value\n1,100\n2,N/A\n3,300\n",
+      configName: "config.csv",
+      templateText: "{% for r in csv_rows %}{{ r.id }}:{{ r.value }}\n{% endfor %}",
+      templateName: "template.j2",
+      settings: DEFAULT_SETTINGS,
+    });
+
+    expect(result.configError).toBeNull();
+    expect(result.templateError).toBeNull();
+    expect(result.output).toBe("1:100\n2:N/A\n3:300\n");
+  });
+});
+```
+
+- [ ] **Step 6: Run the test to verify it fails first (red)**
+
+Run:
+```bash
+cd web && npx vitest run src/worker/pyodide-runtime.node.test.ts
+```
+Expected at this point: FAIL — but it must fail for the *right* reason. Before the implementation of Step 4 is correct, expect either an import error or an assertion mismatch. (If `pyodide-runtime.ts` is already written per Step 4, this step instead confirms the path is exercised; intentionally break the expected string to "WRONG" once to see a red, then restore — documenting the test genuinely discriminates.)
+
+- [ ] **Step 7: Make it pass (green)**
+
+Ensure Step 4's `pyodide-runtime.ts` is correct (especially the `JSON.stringify(payload)` embedding noted above). Re-run:
+```bash
+cd web && npx vitest run src/worker/pyodide-runtime.node.test.ts
+```
+Expected: PASS. **This is the keystone gate** — `features/` runs unmodified in Pyodide and matches the CPython render golden. If micropip cannot install a dep (network), STOP and re-plan the vendoring (do not stub it out).
+
+- [ ] **Step 8: Add a second parity case (TOML path) to prove non-CSV formats**
+
+Append to the test file:
+```ts
+  it("renders a TOML+Jinja fixture", async () => {
+    const result = await generate(pyodide, {
+      configText: 'name = "world"\ncount = 3\n',
+      configName: "config.toml",
+      templateText: "Hello {{ name }} x{{ count }}",
+      templateName: "template.j2",
+      settings: DEFAULT_SETTINGS,
+    });
+    expect(result.configError).toBeNull();
+    expect(result.templateError).toBeNull();
+    expect(result.output).toBe("Hello world x3");
+  });
+```
+Run the same command; expected: both tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/vitest.config.ts web/src/worker/types.ts web/src/worker/features-sources.ts web/src/worker/pyodide-runtime.ts web/src/worker/pyodide-runtime.node.test.ts
+git commit -m "feat(web): boot Pyodide and prove features/ render parity in Node (#<ISSUE>)"
+```
+
+---
+
+### Task 2: Browser worker message contract
+
+**Files:**
+- Create: `web/src/worker/generate.worker.ts`
+- Test: `web/src/worker/contract.test.ts`
+
+- [ ] **Step 1: Write the failing contract test `web/src/worker/contract.test.ts`**
+
+This test exercises the generate wrapper's result shape directly (the worker's `postMessage` plumbing is thin and proven indirectly by the e2e in Task 4). It reuses the booted runtime to assert error-path shape.
+
+```ts
+import { describe, it, expect, beforeAll } from "vitest";
+import { createRequire } from "node:module";
+import { dirname } from "node:path";
+import { loadPyodide } from "pyodide";
+import { bootstrapRuntime, generate, type PyodideLike } from "./pyodide-runtime";
+import { DEFAULT_SETTINGS } from "./types";
+
+const require = createRequire(import.meta.url);
+const indexURL = dirname(require.resolve("pyodide"));
+
+describe("generate() result contract", () => {
+  let pyodide: PyodideLike;
+  beforeAll(async () => {
+    pyodide = await bootstrapRuntime(
+      loadPyodide as unknown as Parameters<typeof bootstrapRuntime>[0],
+      indexURL,
+    );
+  }, 120_000);
+
+  it("surfaces a config parse error in configError (loud, not swallowed)", async () => {
+    const result = await generate(pyodide, {
+      configText: "id,value\n1,2,3\n", // more fields than header -> loud error (#396)
+      configName: "config.csv",
+      templateText: "x",
+      templateName: "template.j2",
+      settings: DEFAULT_SETTINGS,
+    });
+    expect(result.output).toBeNull();
+    expect(result.configError).toContain("Failed to parse CSV");
+  });
+
+  it("surfaces a template error in templateError", async () => {
+    const result = await generate(pyodide, {
+      configText: 'name = "x"\n',
+      configName: "config.toml",
+      templateText: "{% for %}", // invalid jinja syntax
+      templateName: "template.j2",
+      settings: DEFAULT_SETTINGS,
+    });
+    expect(result.output).toBeNull();
+    expect(result.templateError).not.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails/passes appropriately**
+
+Run:
+```bash
+cd web && npx vitest run src/worker/contract.test.ts
+```
+Expected: PASS (the generate logic from Task 1 already supports these paths). If `configError`/`templateError` come back null when they should be set, that is a real defect in the Step-4 generate wrapper — fix it, do not relax the assertion.
+
+- [ ] **Step 3: Write `web/src/worker/generate.worker.ts`**
+
+```ts
+import { loadPyodide } from "pyodide";
+import { bootstrapRuntime, generate, type PyodideLike } from "./pyodide-runtime";
+import type { WorkerInbound, WorkerOutbound } from "./types";
+
+let runtime: PyodideLike | null = null;
+
+function post(msg: WorkerOutbound) {
+  (self as unknown as Worker).postMessage(msg);
+}
+
+self.onmessage = async (event: MessageEvent<WorkerInbound>) => {
+  const msg = event.data;
+  try {
+    if (msg.kind === "init") {
+      runtime = await bootstrapRuntime(
+        loadPyodide as unknown as Parameters<typeof bootstrapRuntime>[0],
+        // Self-hosted distribution copied to /pyodide/ by the vendor-pyodide plugin.
+        new URL("/pyodide/", self.location.origin).toString(),
+      );
+      post({ kind: "ready" });
+      return;
+    }
+    if (msg.kind === "generate") {
+      if (runtime === null) {
+        post({ kind: "error", id: msg.id, message: "runtime not initialized" });
+        return;
+      }
+      const result = await generate(runtime, msg.request);
+      post({ kind: "result", id: msg.id, result });
+    }
+  } catch (err) {
+    const id = msg.kind === "generate" ? msg.id : null;
+    post({ kind: "error", id, message: err instanceof Error ? err.message : String(err) });
+  }
+};
+```
+
+- [ ] **Step 4: Typecheck the worker compiles**
+
+Run:
+```bash
+cd web && npx tsc -b --noEmit
+```
+Expected: no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/worker/generate.worker.ts web/src/worker/contract.test.ts
+git commit -m "feat(web): add generate worker with init/generate/ready/error contract (#<ISSUE>)"
+```
+
+---
+
+### Task 3: Minimal React harness with debounced worker calls
+
+**Files:**
+- Modify: `web/src/App.tsx`
+- Test: `web/src/App.test.tsx`
+
+- [ ] **Step 1: Write the failing component test `web/src/App.test.tsx`**
+
+```tsx
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { App } from "./App";
+
+// Mock the worker module so the component test never boots Pyodide.
+const postMessage = vi.fn();
+let onmessage: ((e: MessageEvent) => void) | null = null;
+
+vi.mock("./worker/generate.worker?worker", () => ({
+  default: class {
+    postMessage = postMessage;
+    set onmessage(fn: (e: MessageEvent) => void) {
+      onmessage = fn;
+    }
+    terminate() {}
+  },
+}));
+
+describe("App harness", () => {
+  beforeEach(() => {
+    postMessage.mockClear();
+    onmessage = null;
+  });
+
+  it("sends init on mount and shows output from a result message", async () => {
+    render(<App />);
+    // init dispatched on mount
+    await waitFor(() => expect(postMessage).toHaveBeenCalledWith({ kind: "init" }));
+
+    // simulate worker ready, then a result
+    onmessage?.({ data: { kind: "ready" } } as MessageEvent);
+    onmessage?.({
+      data: { kind: "result", id: expect.any(Number), result: { output: "HELLO", configError: null, templateError: null } },
+    } as unknown as MessageEvent);
+
+    await waitFor(() => expect(screen.getByText("HELLO")).toBeTruthy());
+  });
+
+  it("shows an error banner when result carries configError", async () => {
+    render(<App />);
+    onmessage?.({ data: { kind: "ready" } } as MessageEvent);
+    onmessage?.({
+      data: { kind: "result", id: 1, result: { output: null, configError: "bad csv", templateError: null } },
+    } as unknown as MessageEvent);
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("bad csv"));
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+```bash
+cd web && npx vitest run src/App.test.tsx
+```
+Expected: FAIL — `App` is still the stub from Task 0.
+
+- [ ] **Step 3: Implement `web/src/App.tsx`**
+
+```tsx
+import { useEffect, useRef, useState } from "react";
+import GenerateWorker from "./worker/generate.worker?worker";
+import type { WorkerOutbound, GenerateResult } from "./worker/types";
+import { DEFAULT_SETTINGS } from "./worker/types";
+
+const DEBOUNCE_MS = 250;
+
+export function App() {
+  const workerRef = useRef<Worker | null>(null);
+  const idRef = useRef(0);
+  const [ready, setReady] = useState(false);
+  const [config, setConfig] = useState("id,value\n1,100\n2,N/A\n3,300\n");
+  const [template, setTemplate] = useState(
+    "{% for r in csv_rows %}{{ r.id }}:{{ r.value }}\n{% endfor %}",
+  );
+  const [result, setResult] = useState<GenerateResult | null>(null);
+
+  useEffect(() => {
+    const worker = new GenerateWorker();
+    workerRef.current = worker;
+    worker.onmessage = (e: MessageEvent<WorkerOutbound>) => {
+      const msg = e.data;
+      if (msg.kind === "ready") setReady(true);
+      else if (msg.kind === "result") setResult(msg.result);
+      else if (msg.kind === "error")
+        setResult({ output: null, configError: msg.message, templateError: null });
+    };
+    worker.postMessage({ kind: "init" });
+    return () => worker.terminate();
+  }, []);
+
+  useEffect(() => {
+    if (!ready) return;
+    const handle = setTimeout(() => {
+      const id = ++idRef.current;
+      workerRef.current?.postMessage({
+        kind: "generate",
+        id,
+        request: {
+          configText: config,
+          configName: "config.csv",
+          templateText: template,
+          templateName: "template.j2",
+          settings: DEFAULT_SETTINGS,
+        },
+      });
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [config, template, ready]);
+
+  const error = result?.configError ?? result?.templateError ?? null;
+
+  return (
+    <main>
+      <h1>Command Ghostwriter</h1>
+      <p>{ready ? "ready" : "loading Pyodide…"}</p>
+      <textarea aria-label="config" value={config} onChange={(e) => setConfig(e.target.value)} />
+      <textarea aria-label="template" value={template} onChange={(e) => setTemplate(e.target.value)} />
+      {error && <div role="alert">{error}</div>}
+      <pre>{result?.output ?? ""}</pre>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 4: Run the component test (green)**
+
+Run:
+```bash
+cd web && npx vitest run src/App.test.tsx
+```
+Expected: PASS.
+
+- [ ] **Step 5: Run the full Vitest suite and build**
+
+Run:
+```bash
+cd web && npx vitest run && npm run build
+```
+Expected: all Vitest files PASS; `npm run build` emits `dist/`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/App.tsx web/src/App.test.tsx
+git commit -m "feat(web): wire debounced worker calls into minimal React harness (#<ISSUE>)"
+```
+
+---
+
+### Task 4: Playwright e2e render-parity smoke (browser proof)
+
+**Files:**
+- Create: `web/playwright.config.ts`, `web/e2e/render-parity.spec.ts`
+
+**Verification caveat (standards §1):** This task requires `npx playwright install chromium`, which downloads a browser over the network. If the execution environment cannot install/run chromium, **mark this task "未検証 (ローカル)"** in the task report and rely on CI to run it. Do NOT delete the test or claim it passed without running it.
+
+- [ ] **Step 1: Create `web/playwright.config.ts`**
+
+```ts
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 180_000, // Pyodide boot in-browser is slow.
+  use: { baseURL: "http://localhost:4173" },
+  webServer: {
+    command: "npm run build && npm run preview",
+    url: "http://localhost:4173",
+    timeout: 240_000,
+    reuseExistingServer: false,
+  },
+});
+```
+
+- [ ] **Step 2: Write `web/e2e/render-parity.spec.ts`**
+
+```ts
+import { test, expect } from "@playwright/test";
+
+test("renders the CSV+Jinja fixture in a real browser", async ({ page }) => {
+  await page.goto("/");
+  // Wait for Pyodide to finish booting in the worker.
+  await expect(page.getByText("ready")).toBeVisible({ timeout: 180_000 });
+  // App seeds the same fixture as the Node keystone test; assert identical output.
+  await expect(page.locator("pre")).toHaveText("1:100\n2:N/A\n3:300\n", { timeout: 60_000 });
+});
+```
+
+- [ ] **Step 3: Install chromium and run the e2e**
+
+Run:
+```bash
+cd web && npx playwright install chromium && npx playwright test
+```
+Expected: PASS (browser proves the same parity as the Node keystone). If chromium install fails due to the network policy, record "未検証 (ローカル) — CIで実行" and proceed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/playwright.config.ts web/e2e/render-parity.spec.ts
+git commit -m "test(web): add Playwright render-parity e2e smoke (#<ISSUE>)"
+```
+
+---
+
+### Task 5: CI wiring for the `web/` workspace
+
+The repo's CI must run the new Vitest suite (and the e2e where a browser is available) so the keystone gate is enforced on every PR. This task adds a minimal job; the existing Python jobs are untouched.
+
+**Files:**
+- Modify: `.github/workflows/` — add a `web` job (exact file determined at execution by reading the existing workflow layout; do not guess the filename).
+
+- [ ] **Step 1: Inspect the existing workflow structure**
+
+Run:
+```bash
+ls .github/workflows
+```
+Read the most relevant CI workflow to find where jobs are defined and how Node is set up (if at all). Record the matrix/runner conventions.
+
+- [ ] **Step 2: Add a `web-test` job**
+
+Add a job that: checks out, sets up Node 22, runs `cd web && npm ci && npm run build && npx vitest run`. Gate the Playwright e2e behind `npx playwright install --with-deps chromium` only if the runner supports it; otherwise keep e2e as a separate allow-listed job. Match the existing workflow's style (concurrency, permissions, `runs-on`).
+
+```yaml
+  web-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install and build web
+        run: |
+          cd web
+          npm ci
+          npm run build
+      - name: Vitest (Pyodide-in-Node keystone)
+        run: |
+          cd web
+          npx vitest run
+```
+
+- [ ] **Step 3: Verify the workflow is valid YAML**
+
+Run:
+```bash
+npx --yes yaml-lint .github/workflows/<edited-file> 2>/dev/null || python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/<edited-file>'))"
+```
+Expected: no parse error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/<edited-file>
+git commit -m "ci(web): run web Vitest keystone suite on PRs (#<ISSUE>)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage (against `2026-06-12-streamlit-to-vercel-migration-design.md`):**
+- Pyodide Web Worker, self-host/CDN非依存 → Tasks 0/1/2 (vendored, jsdelivr never used). ✓
+- `features/` reused unmodified, BytesIO+`.name` IF → Task 1 generate wrapper. ✓
+- micropip deps (jinja2/pyyaml/pydantic/chardet; markupsafe transitive) → Task 1 `PY_DEPS`. ✓ (python-box/toml correctly excluded — app.py-only, P2.)
+- Thin postMessage contract init/generate/ready/error → Task 2. ✓
+- 250ms debounce, UI non-blocking → Task 3. ✓
+- Inline error banner (config=parse, template) → Task 3 `role="alert"`. ✓
+- Render-layer parity as the acceptance criterion (not dict compare) → Tasks 1/4 assert exact rendered strings, matching `test_csv_render_layer_parity`. ✓
+- Vitest (component) + Playwright (built static e2e) → Tasks 3/4. ✓
+- Verifiability honesty for browser-dependent checks → Task 4 caveat. ✓
+- **Deferred (NOT in P1a, by design):** CodeMirror, D&D, settings drawer, samples, how-to modal, markdown/config-debug modes, download, i18n catalog, Vercel deploy + runbook. These are P1b/P1c — flagged in the plan header scope boundary.
+
+**2. Placeholder scan:** The only intentional `<ISSUE>` / `<edited-file>` tokens are resolved at execution (issue number created at handoff; workflow filename read in Task 5 Step 1). All code steps contain complete code. The Step-4 `generate` string-embedding subtlety is called out explicitly with the concrete `JSON.stringify(payload)` fix rather than left vague.
+
+**3. Type consistency:** `GenerateRequest`/`GenerateResult`/`GenerateSettings`/`WorkerInbound`/`WorkerOutbound`/`DEFAULT_SETTINGS` defined once in `types.ts` (Task 1) and consumed identically in Tasks 2–4. `bootstrapRuntime(loadPyodide, indexURL)` and `generate(pyodide, request)` signatures are stable across the Node test, the contract test, and the browser worker. `PyodideLike` is the single structural type used everywhere.
+
+**Open dependency for execution:** A GitHub issue (sub-issue of #395) must be opened before the first commit; its number replaces `<ISSUE>` in every commit message. Commits are authored `noreply@anthropic.com` / `Claude` and re-authored if they land Unverified (per session convention). PRs/merges through P3 are pre-authorized by the owner.

--- a/scripts/inspect_release_archive.sh
+++ b/scripts/inspect_release_archive.sh
@@ -17,7 +17,7 @@
 #   --expect-path   assert this exact member path exists in the archive
 #                   (exit non-zero when absent)
 #
-# Supported formats: .tar.gz / .tgz / .tar.xz / .zip
+# Supported formats: .tar.gz / .tgz / .tar.xz / .tar.bz2 / .tbz2 / .zip
 #
 # Exit codes:
 #   0  inspected OK (and --expect-path member found, when given)
@@ -75,6 +75,7 @@ fi
 case "${archive}" in
   *.tar.gz | *.tgz) list_cmd=(tar -tzf "${archive}") ;;
   *.tar.xz) list_cmd=(tar -tJf "${archive}") ;;
+  *.tar.bz2 | *.tbz2) list_cmd=(tar -tjf "${archive}") ;;
   *.zip) list_cmd=(python3 -c 'import sys, zipfile; print("\n".join(zipfile.ZipFile(sys.argv[1]).namelist()))' "${archive}") ;;
   *)
     echo "inspect_release_archive: unsupported archive extension: ${archive}" >&2

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+dist-ssr
+public/pyodide
+test-results
+playwright-report
+*.local

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -5,3 +5,4 @@ public/pyodide
 test-results
 playwright-report
 *.local
+*.tsbuildinfo

--- a/web/e2e/render-parity.spec.ts
+++ b/web/e2e/render-parity.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "@playwright/test";
+
+test("renders the CSV+Jinja fixture in a real browser", async ({ page }) => {
+  await page.goto("/");
+  // Wait for Pyodide to finish booting in the worker.
+  await expect(page.getByText("ready")).toBeVisible({ timeout: 180_000 });
+  // App seeds the same fixture as the Node keystone test; assert byte-identical output
+  // (textContent, not toHaveText, to preserve the exact newlines).
+  await expect
+    .poll(async () => await page.locator("pre").textContent(), { timeout: 60_000 })
+    .toBe("1:100\n2:N/A\n3:300\n");
+});

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Command Ghostwriter</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,3147 @@
+{
+  "name": "command-ghostwriter-web",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "command-ghostwriter-web",
+      "version": "0.0.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.56.1",
+        "@testing-library/react": "^16.0.1",
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.4",
+        "jsdom": "^25.0.1",
+        "pyodide": "^0.26.4",
+        "typescript": "^5.6.3",
+        "vite": "^5.4.11",
+        "vitest": "^2.1.8"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.36",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.36.tgz",
+      "integrity": "sha512-lVq/Df7LXlO79MVaaUHztSwWiG9oXoWHlgvNS51v8Dpd4+G4/VIy6qYePTw31nAVls33nUtnfezYeLkYAak9dg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.372",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
+      "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pyodide": {
+      "version": "0.26.4",
+      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.26.4.tgz",
+      "integrity": "sha512-z2CHsjVlhhJi5tYBF0AYAfNEPo3zq/z+xOpFtk1tweJkRaTqU4UK/7pLvo8DBU2VDPH31vB3pSI+8fnoqrVrFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ws": "^8.5.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "command-ghostwriter-web",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -14,6 +15,7 @@
       "devDependencies": {
         "@playwright/test": "^1.56.1",
         "@testing-library/react": "^16.0.1",
+        "@types/node": "^22.19.21",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1374,6 +1376,16 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -2823,6 +2835,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "command-ghostwriter-web",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --port 4173 --strictPort",
+    "test": "vitest run",
+    "e2e": "playwright test"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.56.1",
+    "@testing-library/react": "^16.0.1",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^25.0.1",
+    "pyodide": "^0.26.4",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.11",
+    "vitest": "^2.1.8"
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -4,6 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "postinstall": "bash scripts/vendor-pyodide-wheels.sh",
+    "vendor-pyodide-wheels": "bash scripts/vendor-pyodide-wheels.sh",
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview --port 4173 --strictPort",
@@ -17,6 +19,7 @@
   "devDependencies": {
     "@playwright/test": "^1.56.1",
     "@testing-library/react": "^16.0.1",
+    "@types/node": "^22.19.21",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 180_000, // Pyodide boot in-browser is slow.
+  use: { baseURL: "http://localhost:4173" },
+  webServer: {
+    command: "npm run build && npm run preview",
+    url: "http://localhost:4173",
+    timeout: 240_000,
+    reuseExistingServer: false,
+  },
+});

--- a/web/scripts/vendor-pyodide-wheels.sh
+++ b/web/scripts/vendor-pyodide-wheels.sh
@@ -23,9 +23,16 @@
 # loudly; never leave a half-provisioned distribution behind.
 set -euo pipefail
 
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: python3 is required to vendor Pyodide wheels (registers chardet in pyodide-lock.json)" >&2
+  exit 1
+fi
+
 PYODIDE_VERSION="0.26.4"
 RELEASE_TARBALL="pyodide-${PYODIDE_VERSION}.tar.bz2"
 RELEASE_URL="https://github.com/pyodide/pyodide/releases/download/${PYODIDE_VERSION}/${RELEASE_TARBALL}"
+# sha256 of the release tarball, verified via scripts/inspect_release_archive.sh (Refs CLAUDE.local.md "Release-archive preflight").
+PYODIDE_SHA256="f6ee209650babf1669f1a9560a5f89f66c0d38aacc2d5b8cd8b4dd6a7537cba9"
 
 # Pure-python chardet wheel pinned to match the repo (chardet>=5.2,<6) and uv.lock.
 CHARDET_WHEEL="chardet-5.2.0-py3-none-any.whl"
@@ -35,8 +42,6 @@ CHARDET_SHA256="e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970
 # Wheels to pull out of the release tarball (paths inside the `pyodide/` member).
 # Exact filenames are pinned by node_modules/pyodide/pyodide-lock.json.
 RELEASE_WHEELS=(
-  "micropip-0.6.0-py3-none-any.whl"
-  "packaging-23.2-py3-none-any.whl"
   "Jinja2-3.1.3-py3-none-any.whl"
   "MarkupSafe-2.1.5-cp312-cp312-pyodide_2024_0_wasm32.whl"
   "PyYAML-6.0.1-cp312-cp312-pyodide_2024_0_wasm32.whl"
@@ -67,9 +72,16 @@ if [ "${have_all_release_wheels}" -eq 0 ]; then
   tmp="$(mktemp -d)"
   trap 'rm -rf "${tmp}"' EXIT
   curl -fsSL -m 600 -o "${tmp}/${RELEASE_TARBALL}" "${RELEASE_URL}"
+  actual_tar_sha="$(sha256sum "${tmp}/${RELEASE_TARBALL}" | cut -d' ' -f1)"
+  if [ "${actual_tar_sha}" != "${PYODIDE_SHA256}" ]; then
+    echo "error: ${RELEASE_TARBALL} sha256 mismatch: ${actual_tar_sha} != ${PYODIDE_SHA256}" >&2
+    rm -f "${tmp}/${RELEASE_TARBALL}"
+    exit 1
+  fi
   members=()
   for whl in "${RELEASE_WHEELS[@]}"; do members+=("pyodide/${whl}"); done
-  # Single top-level dir `pyodide/`; --strip-components=1 lands wheels directly.
+  # Verified via scripts/inspect_release_archive.sh: single top-level dir `pyodide/`,
+  # wheels are flat members `pyodide/<wheel>.whl`; --strip-components=1 lands them in dist_dir.
   tar -xjf "${tmp}/${RELEASE_TARBALL}" -C "${dist_dir}" --strip-components=1 "${members[@]}"
   for whl in "${RELEASE_WHEELS[@]}"; do
     [ -f "${dist_dir}/${whl}" ] || { echo "error: ${whl} missing after extract" >&2; exit 1; }

--- a/web/scripts/vendor-pyodide-wheels.sh
+++ b/web/scripts/vendor-pyodide-wheels.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Vendor the Python wheels that features/ needs into the local Pyodide
+# distribution so the runtime can loadPackage() them fully offline. Refs #398.
+#
+# Why this exists:
+#   - The npm `pyodide` package ships ONLY the core runtime (pyodide.asm.wasm,
+#     python_stdlib.zip, pyodide-lock.json) -- ZERO wheels, not even micropip.
+#   - At runtime Pyodide normally fetches wheels from cdn.jsdelivr.net, which is
+#     403-blocked in the build/CI environment.
+#   - The WASM wheels (PyYAML, pydantic_core, MarkupSafe) are
+#     `pyodide_2024_0_wasm32` builds that exist ONLY in the official Pyodide
+#     distribution; PyPI has no such wheels. They are obtained here from the
+#     official Pyodide GitHub release tarball (reachable), not the CDN.
+#   - chardet is not in the Pyodide distribution; its pure-python wheel
+#     (5.2.0, matching the repo pin chardet>=5.2,<6 and uv.lock) comes from PyPI
+#     and is registered into the local pyodide-lock.json so loadPackage resolves it.
+#
+# Idempotent: re-running is a no-op once the wheels and the chardet lock entry
+# are present. node_modules/pyodide is gitignored and rebuilt by `npm install`,
+# so this runs as a setup step (npm postinstall / SessionStart), not a commit.
+#
+# Exit non-zero (set -e) on any download/checksum/extraction failure -- fail
+# loudly; never leave a half-provisioned distribution behind.
+set -euo pipefail
+
+PYODIDE_VERSION="0.26.4"
+RELEASE_TARBALL="pyodide-${PYODIDE_VERSION}.tar.bz2"
+RELEASE_URL="https://github.com/pyodide/pyodide/releases/download/${PYODIDE_VERSION}/${RELEASE_TARBALL}"
+
+# Pure-python chardet wheel pinned to match the repo (chardet>=5.2,<6) and uv.lock.
+CHARDET_WHEEL="chardet-5.2.0-py3-none-any.whl"
+CHARDET_URL="https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/${CHARDET_WHEEL}"
+CHARDET_SHA256="e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"
+
+# Wheels to pull out of the release tarball (paths inside the `pyodide/` member).
+# Exact filenames are pinned by node_modules/pyodide/pyodide-lock.json.
+RELEASE_WHEELS=(
+  "micropip-0.6.0-py3-none-any.whl"
+  "packaging-23.2-py3-none-any.whl"
+  "Jinja2-3.1.3-py3-none-any.whl"
+  "MarkupSafe-2.1.5-cp312-cp312-pyodide_2024_0_wasm32.whl"
+  "PyYAML-6.0.1-cp312-cp312-pyodide_2024_0_wasm32.whl"
+  "pydantic-2.7.0-py3-none-any.whl"
+  "pydantic_core-2.18.1-cp312-cp312-pyodide_2024_0_wasm32.whl"
+  "annotated_types-0.6.0-py3-none-any.whl"
+  "typing_extensions-4.11.0-py3-none-any.whl"
+)
+
+# Resolve the local Pyodide distribution directory from web/node_modules.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+web_dir="$(cd "${script_dir}/.." && pwd)"
+dist_dir="${web_dir}/node_modules/pyodide"
+lock_file="${dist_dir}/pyodide-lock.json"
+
+if [ ! -f "${lock_file}" ]; then
+  echo "error: ${lock_file} not found; run 'npm install' in web/ first" >&2
+  exit 1
+fi
+
+have_all_release_wheels=1
+for whl in "${RELEASE_WHEELS[@]}"; do
+  [ -f "${dist_dir}/${whl}" ] || have_all_release_wheels=0
+done
+
+if [ "${have_all_release_wheels}" -eq 0 ]; then
+  echo "vendoring ${#RELEASE_WHEELS[@]} wheels from Pyodide ${PYODIDE_VERSION} release ..."
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "${tmp}"' EXIT
+  curl -fsSL -m 600 -o "${tmp}/${RELEASE_TARBALL}" "${RELEASE_URL}"
+  members=()
+  for whl in "${RELEASE_WHEELS[@]}"; do members+=("pyodide/${whl}"); done
+  # Single top-level dir `pyodide/`; --strip-components=1 lands wheels directly.
+  tar -xjf "${tmp}/${RELEASE_TARBALL}" -C "${dist_dir}" --strip-components=1 "${members[@]}"
+  for whl in "${RELEASE_WHEELS[@]}"; do
+    [ -f "${dist_dir}/${whl}" ] || { echo "error: ${whl} missing after extract" >&2; exit 1; }
+  done
+  echo "release wheels vendored."
+else
+  echo "release wheels already present; skipping."
+fi
+
+# chardet pure-python wheel from PyPI, checksum-verified.
+if [ ! -f "${dist_dir}/${CHARDET_WHEEL}" ]; then
+  echo "downloading ${CHARDET_WHEEL} ..."
+  curl -fsSL -m 120 -o "${dist_dir}/${CHARDET_WHEEL}" "${CHARDET_URL}"
+fi
+actual_sha="$(sha256sum "${dist_dir}/${CHARDET_WHEEL}" | cut -d' ' -f1)"
+if [ "${actual_sha}" != "${CHARDET_SHA256}" ]; then
+  echo "error: ${CHARDET_WHEEL} sha256 mismatch: ${actual_sha} != ${CHARDET_SHA256}" >&2
+  rm -f "${dist_dir}/${CHARDET_WHEEL}"
+  exit 1
+fi
+
+# Register chardet in the local lock so loadPackage(["chardet"]) resolves offline.
+python3 - "${lock_file}" "${dist_dir}/${CHARDET_WHEEL}" "${CHARDET_SHA256}" <<'PY'
+import json, sys
+lock_file, wheel_path, sha = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(lock_file) as fh:
+    lock = json.load(fh)
+wheel_name = wheel_path.rsplit("/", 1)[-1]
+lock["packages"]["chardet"] = {
+    "name": "chardet",
+    "version": "5.2.0",
+    "file_name": wheel_name,
+    "install_dir": "site",
+    "sha256": sha,
+    "package_type": "package",
+    "imports": ["chardet"],
+    "depends": [],
+    "unvendored_tests": False,
+}
+with open(lock_file, "w") as fh:
+    json.dump(lock, fh)
+print("chardet registered in", lock_file)
+PY
+
+echo "Pyodide wheel vendoring complete."

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { App } from "./App";
+
+const postMessage = vi.fn();
+let onmessage: ((e: MessageEvent) => void) | null = null;
+
+vi.mock("./worker/generate.worker?worker", () => ({
+  default: class {
+    postMessage = postMessage;
+    set onmessage(fn: (e: MessageEvent) => void) {
+      onmessage = fn;
+    }
+    terminate() {}
+  },
+}));
+
+describe("App harness", () => {
+  beforeEach(() => {
+    postMessage.mockClear();
+    onmessage = null;
+  });
+
+  it("sends init on mount and shows output from a result message", async () => {
+    render(<App />);
+    await waitFor(() => expect(postMessage).toHaveBeenCalledWith({ kind: "init" }));
+
+    onmessage?.({ data: { kind: "ready" } } as MessageEvent);
+    onmessage?.({
+      data: { kind: "result", id: 1, result: { output: "HELLO", configError: null, templateError: null } },
+    } as MessageEvent);
+
+    await waitFor(() => expect(screen.getByText("HELLO")).toBeTruthy());
+  });
+
+  it("shows an error banner when result carries configError", async () => {
+    render(<App />);
+    onmessage?.({ data: { kind: "ready" } } as MessageEvent);
+    onmessage?.({
+      data: { kind: "result", id: 1, result: { output: null, configError: "bad csv", templateError: null } },
+    } as MessageEvent);
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("bad csv"));
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,17 @@ import { DEFAULT_SETTINGS } from "./worker/types";
 
 const DEBOUNCE_MS = 250;
 
+function viewError(result: GenerateResult | null): string | null {
+  if (result === null) return null;
+  if (result.configError !== null) return result.configError;
+  return result.templateError;
+}
+
+function viewOutput(result: GenerateResult | null): string {
+  if (result === null) return "";
+  return result.output ?? "";
+}
+
 export function App() {
   const workerRef = useRef<Worker | null>(null);
   const idRef = useRef(0);
@@ -48,16 +59,17 @@ export function App() {
     return () => clearTimeout(handle);
   }, [config, template, ready]);
 
-  const error = result?.configError ?? result?.templateError ?? null;
+  const error = viewError(result);
+  const status = ready ? "ready" : "loading Pyodide...";
 
   return (
     <main>
       <h1>Command Ghostwriter</h1>
-      <p>{ready ? "ready" : "loading Pyodide..."}</p>
+      <p>{status}</p>
       <textarea aria-label="config" value={config} onChange={(e) => setConfig(e.target.value)} />
       <textarea aria-label="template" value={template} onChange={(e) => setTemplate(e.target.value)} />
-      {error && <div role="alert">{error}</div>}
-      <pre>{result?.output ?? ""}</pre>
+      {error !== null && <div role="alert">{error}</div>}
+      <pre>{viewOutput(result)}</pre>
     </main>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,3 @@
+export function App() {
+  return <main>Command Ghostwriter</main>;
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,3 +1,63 @@
+import { useEffect, useRef, useState } from "react";
+import GenerateWorker from "./worker/generate.worker?worker";
+import type { WorkerOutbound, GenerateResult } from "./worker/types";
+import { DEFAULT_SETTINGS } from "./worker/types";
+
+const DEBOUNCE_MS = 250;
+
 export function App() {
-  return <main>Command Ghostwriter</main>;
+  const workerRef = useRef<Worker | null>(null);
+  const idRef = useRef(0);
+  const [ready, setReady] = useState(false);
+  const [config, setConfig] = useState("id,value\n1,100\n2,N/A\n3,300\n");
+  const [template, setTemplate] = useState(
+    "{% for r in csv_rows %}{{ r.id }}:{{ r.value }}\n{% endfor %}",
+  );
+  const [result, setResult] = useState<GenerateResult | null>(null);
+
+  useEffect(() => {
+    const worker = new GenerateWorker();
+    workerRef.current = worker;
+    worker.onmessage = (e: MessageEvent<WorkerOutbound>) => {
+      const msg = e.data;
+      if (msg.kind === "ready") setReady(true);
+      else if (msg.kind === "result") setResult(msg.result);
+      else if (msg.kind === "error")
+        setResult({ output: null, configError: msg.message, templateError: null });
+    };
+    worker.postMessage({ kind: "init" });
+    return () => worker.terminate();
+  }, []);
+
+  useEffect(() => {
+    if (!ready) return;
+    const handle = setTimeout(() => {
+      const id = ++idRef.current;
+      workerRef.current?.postMessage({
+        kind: "generate",
+        id,
+        request: {
+          configText: config,
+          configName: "config.csv",
+          templateText: template,
+          templateName: "template.j2",
+          settings: DEFAULT_SETTINGS,
+        },
+      });
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [config, template, ready]);
+
+  const error = result?.configError ?? result?.templateError ?? null;
+
+  return (
+    <main>
+      <h1>Command Ghostwriter</h1>
+      <p>{ready ? "ready" : "loading Pyodide..."}</p>
+      <textarea aria-label="config" value={config} onChange={(e) => setConfig(e.target.value)} />
+      <textarea aria-label="template" value={template} onChange={(e) => setTemplate(e.target.value)} />
+      {error && <div role="alert">{error}</div>}
+      <pre>{result?.output ?? ""}</pre>
+    </main>
+  );
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/web/src/worker/features-sources.ts
+++ b/web/src/worker/features-sources.ts
@@ -8,7 +8,7 @@ const raw = import.meta.glob("../../../features/**/*.py", {
 
 export const FEATURES_SOURCES: Record<string, string> = Object.fromEntries(
   Object.entries(raw).map(([key, source]) => {
-    const idx = key.lastIndexOf("features/");
-    return [key.slice(idx), source];
+    const idx = key.lastIndexOf("/features/");
+    return [key.slice(idx + 1), source];
   }),
 );

--- a/web/src/worker/features-sources.ts
+++ b/web/src/worker/features-sources.ts
@@ -1,0 +1,14 @@
+// Import every features/*.py as a raw string at build time (single source of truth).
+// Keys look like "../../../features/core.py"; we normalize to "features/core.py".
+const raw = import.meta.glob("../../../features/**/*.py", {
+  query: "?raw",
+  eager: true,
+  import: "default",
+}) as Record<string, string>;
+
+export const FEATURES_SOURCES: Record<string, string> = Object.fromEntries(
+  Object.entries(raw).map(([key, source]) => {
+    const idx = key.lastIndexOf("features/");
+    return [key.slice(idx), source];
+  }),
+);

--- a/web/src/worker/generate.worker.ts
+++ b/web/src/worker/generate.worker.ts
@@ -1,0 +1,35 @@
+import { loadPyodide } from "pyodide";
+import { bootstrapRuntime, generate, type PyodideLike } from "./pyodide-runtime";
+import type { WorkerInbound, WorkerOutbound } from "./types";
+
+let runtime: PyodideLike | null = null;
+
+function post(msg: WorkerOutbound) {
+  (self as unknown as Worker).postMessage(msg);
+}
+
+self.onmessage = async (event: MessageEvent<WorkerInbound>) => {
+  const msg = event.data;
+  try {
+    if (msg.kind === "init") {
+      runtime = await bootstrapRuntime(
+        loadPyodide as unknown as Parameters<typeof bootstrapRuntime>[0],
+        // Self-hosted distribution copied to /pyodide/ by the vendor-pyodide plugin.
+        new URL("/pyodide/", self.location.origin).toString(),
+      );
+      post({ kind: "ready" });
+      return;
+    }
+    if (msg.kind === "generate") {
+      if (runtime === null) {
+        post({ kind: "error", id: msg.id, message: "runtime not initialized" });
+        return;
+      }
+      const result = await generate(runtime, msg.request);
+      post({ kind: "result", id: msg.id, result });
+    }
+  } catch (err) {
+    const id = msg.kind === "generate" ? msg.id : null;
+    post({ kind: "error", id, message: err instanceof Error ? err.message : String(err) });
+  }
+};

--- a/web/src/worker/pyodide-runtime.node.test.ts
+++ b/web/src/worker/pyodide-runtime.node.test.ts
@@ -56,4 +56,16 @@ describe("features/ render parity in Pyodide (Node)", () => {
     expect(result.output).toBeNull();
     expect(result.configError).toContain("Failed to parse CSV");
   });
+
+  it("surfaces a template error in templateError, not output", async () => {
+    const result = await generate(pyodide, {
+      configText: 'name = "x"\n',
+      configName: "config.toml",
+      templateText: "{% for %}", // invalid jinja syntax
+      templateName: "template.j2",
+      settings: DEFAULT_SETTINGS,
+    });
+    expect(result.output).toBeNull();
+    expect(result.templateError).not.toBeNull();
+  });
 });

--- a/web/src/worker/pyodide-runtime.node.test.ts
+++ b/web/src/worker/pyodide-runtime.node.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { createRequire } from "node:module";
+import { dirname } from "node:path";
+import { loadPyodide } from "pyodide";
+import { bootstrapRuntime, generate, type PyodideLike } from "./pyodide-runtime";
+import { DEFAULT_SETTINGS } from "./types";
+
+const require = createRequire(import.meta.url);
+const indexURL = dirname(require.resolve("pyodide"));
+
+describe("features/ render parity in Pyodide (Node)", () => {
+  let pyodide: PyodideLike;
+
+  beforeAll(async () => {
+    pyodide = await bootstrapRuntime(
+      loadPyodide as unknown as Parameters<typeof bootstrapRuntime>[0],
+      indexURL,
+    );
+  }, 120_000);
+
+  it("renders a CSV+Jinja fixture byte-identically to the CPython golden", async () => {
+    const result = await generate(pyodide, {
+      configText: "id,value\n1,100\n2,N/A\n3,300\n",
+      configName: "config.csv",
+      templateText: "{% for r in csv_rows %}{{ r.id }}:{{ r.value }}\n{% endfor %}",
+      templateName: "template.j2",
+      settings: DEFAULT_SETTINGS,
+    });
+
+    expect(result.configError).toBeNull();
+    expect(result.templateError).toBeNull();
+    expect(result.output).toBe("1:100\n2:N/A\n3:300\n");
+  });
+
+  it("renders a TOML+Jinja fixture", async () => {
+    const result = await generate(pyodide, {
+      configText: 'name = "world"\ncount = 3\n',
+      configName: "config.toml",
+      templateText: "Hello {{ name }} x{{ count }}",
+      templateName: "template.j2",
+      settings: DEFAULT_SETTINGS,
+    });
+    expect(result.configError).toBeNull();
+    expect(result.templateError).toBeNull();
+    expect(result.output).toBe("Hello world x3");
+  });
+});

--- a/web/src/worker/pyodide-runtime.node.test.ts
+++ b/web/src/worker/pyodide-runtime.node.test.ts
@@ -44,4 +44,16 @@ describe("features/ render parity in Pyodide (Node)", () => {
     expect(result.templateError).toBeNull();
     expect(result.output).toBe("Hello world x3");
   });
+
+  it("surfaces a config parse error in configError, not output", async () => {
+    const result = await generate(pyodide, {
+      configText: "id,value\n1,2,3\n", // a data row with more fields than the header -> loud CSV error
+      configName: "config.csv",
+      templateText: "{% for r in csv_rows %}{{ r.id }}\n{% endfor %}",
+      templateName: "template.j2",
+      settings: DEFAULT_SETTINGS,
+    });
+    expect(result.output).toBeNull();
+    expect(result.configError).toContain("Failed to parse CSV");
+  });
 });

--- a/web/src/worker/pyodide-runtime.ts
+++ b/web/src/worker/pyodide-runtime.ts
@@ -9,7 +9,6 @@ export interface PyodideLike {
   };
   loadPackage(names: string[]): Promise<void>;
   runPythonAsync(code: string): Promise<unknown>;
-  globals: { get(name: string): unknown };
 }
 
 export type LoadPyodideFn = (opts: { indexURL: string }) => Promise<PyodideLike>;
@@ -56,8 +55,9 @@ export async function generate(
   pyodide: PyodideLike,
   request: GenerateRequest,
 ): Promise<GenerateResult> {
-  // Embed the request as a valid Python string literal (JSON escapes are a subset
-  // of Python's), then json.loads it inside Python -- no quote/backtick injection.
+  // Double JSON-encode: the inner encodes the request, the outer turns that into a
+  // valid Python string literal (JSON and Python share \uXXXX escapes, so non-ASCII
+  // and quotes are safe). json.loads() inside Python decodes it -- no code injection.
   const pyPayloadLiteral = JSON.stringify(JSON.stringify(request));
   const code = [
     "import json",

--- a/web/src/worker/pyodide-runtime.ts
+++ b/web/src/worker/pyodide-runtime.ts
@@ -1,0 +1,78 @@
+import type { GenerateRequest, GenerateResult } from "./types";
+import { FEATURES_SOURCES } from "./features-sources";
+
+// Minimal structural type for the bits of the Pyodide API we use.
+export interface PyodideLike {
+  FS: {
+    mkdirTree(path: string): void;
+    writeFile(path: string, data: string, opts?: { encoding: string }): void;
+  };
+  loadPackage(names: string[]): Promise<void>;
+  runPythonAsync(code: string): Promise<unknown>;
+  globals: { get(name: string): unknown };
+}
+
+export type LoadPyodideFn = (opts: { indexURL: string }) => Promise<PyodideLike>;
+
+// Third-party packages that features/ actually imports. loadPackage resolves
+// these and all transitive deps (markupsafe, pydantic_core, typing-extensions,
+// annotated-types) from the LOCAL Pyodide distribution at indexURL -- no CDN and
+// no PyPI at runtime. The jsdelivr CDN is unreachable in this environment, and
+// the WASM wheels (PyYAML, pydantic_core, MarkupSafe) exist only in the Pyodide
+// distribution, so the wheels are vendored into the distribution ahead of time
+// by scripts/vendor-pyodide-wheels.sh (chardet 5.2.0 is added to the local lock
+// there). If a wheel is missing, loadPackage fails loudly -- the truthful signal.
+const PY_DEPS = ["jinja2", "pyyaml", "pydantic", "chardet"];
+
+export async function bootstrapRuntime(
+  loadPyodide: LoadPyodideFn,
+  indexURL: string,
+): Promise<PyodideLike> {
+  const pyodide = await loadPyodide({ indexURL });
+
+  // Load every features/ dependency from the local distribution (offline).
+  await pyodide.loadPackage(PY_DEPS);
+
+  // Mount features/ into the Pyodide FS (single source of truth, written verbatim).
+  for (const [relPath, source] of Object.entries(FEATURES_SOURCES)) {
+    const dir = relPath.slice(0, relPath.lastIndexOf("/"));
+    pyodide.FS.mkdirTree("/" + dir);
+    pyodide.FS.writeFile("/" + relPath, source, { encoding: "utf8" });
+  }
+
+  await pyodide.runPythonAsync(
+    [
+      "import sys",
+      'if "/" not in sys.path:',
+      '    sys.path.insert(0, "/")',
+      "import features.core  # fail loudly here if a dep or import is missing",
+    ].join("\n"),
+  );
+
+  return pyodide;
+}
+
+export async function generate(
+  pyodide: PyodideLike,
+  request: GenerateRequest,
+): Promise<GenerateResult> {
+  // Embed the request as a valid Python string literal (JSON escapes are a subset
+  // of Python's), then json.loads it inside Python -- no quote/backtick injection.
+  const pyPayloadLiteral = JSON.stringify(JSON.stringify(request));
+  const code = [
+    "import json",
+    "from io import BytesIO",
+    "from features.core import AppCore",
+    `req = json.loads(${pyPayloadLiteral})`,
+    "s = req['settings']",
+    "config_file = BytesIO(req['configText'].encode('utf-8'))",
+    "config_file.name = req['configName']",
+    "template_file = BytesIO(req['templateText'].encode('utf-8'))",
+    "template_file.name = req['templateName']",
+    "core = AppCore('config load failed', 'template load failed')",
+    "core.load_config_file(config_file, s['csvRowsName'], s['enableAutoTranscoding'], s['enableFillNan'], s['fillNanWith']).load_template_file(template_file, s['enableAutoTranscoding']).apply(s['formatType'], s['isStrictUndefined'])",
+    "json.dumps({'output': core.formatted_text, 'configError': core.config_error_message, 'templateError': core.template_error_message})",
+  ].join("\n");
+  const resultJson = (await pyodide.runPythonAsync(code)) as string;
+  return JSON.parse(resultJson) as GenerateResult;
+}

--- a/web/src/worker/types.ts
+++ b/web/src/worker/types.ts
@@ -1,0 +1,41 @@
+export interface GenerateSettings {
+  csvRowsName: string;
+  enableAutoTranscoding: boolean;
+  enableFillNan: boolean;
+  fillNanWith: string;
+  formatType: number; // 0..4
+  isStrictUndefined: boolean;
+}
+
+export interface GenerateRequest {
+  configText: string;
+  configName: string; // e.g. "config.csv" -- extension drives parser selection
+  templateText: string;
+  templateName: string; // e.g. "template.j2"
+  settings: GenerateSettings;
+}
+
+export interface GenerateResult {
+  output: string | null;
+  configError: string | null;
+  templateError: string | null;
+}
+
+export const DEFAULT_SETTINGS: GenerateSettings = {
+  csvRowsName: "csv_rows",
+  enableAutoTranscoding: true,
+  enableFillNan: true,
+  fillNanWith: "#",
+  formatType: 0,
+  isStrictUndefined: true,
+};
+
+// Browser worker message contract.
+export type WorkerInbound =
+  | { kind: "init" }
+  | { kind: "generate"; id: number; request: GenerateRequest };
+
+export type WorkerOutbound =
+  | { kind: "ready" }
+  | { kind: "result"; id: number; result: GenerateResult }
+  | { kind: "error"; id: number | null; message: string };

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client", "vitest/globals"]
+  },
+  "include": ["src", "e2e"]
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -16,7 +16,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "types": ["vite/client", "vitest/globals"]
+    "types": ["node", "vite/client", "vitest/globals"]
   },
   "include": ["src", "e2e"]
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { createRequire } from "node:module";
+import { cpSync, existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+const pyodideDir = dirname(require.resolve("pyodide"));
+
+// Self-host the vendored Pyodide distribution (jsdelivr CDN is blocked).
+function vendorPyodide() {
+  return {
+    name: "vendor-pyodide",
+    buildStart() {
+      const dest = resolve(__dirname, "public/pyodide");
+      if (!existsSync(dest)) {
+        cpSync(pyodideDir, dest, { recursive: true });
+      }
+    },
+  };
+}
+
+export default defineConfig({
+  plugins: [react(), vendorPyodide()],
+  server: {
+    // Allow Vite to read ../features (single source of truth for the Python core).
+    fs: { allow: [".."] },
+  },
+  worker: { format: "es" },
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { createRequire } from "node:module";
-import { cpSync, existsSync } from "node:fs";
+import { cpSync, rmSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 const require = createRequire(import.meta.url);
@@ -13,9 +13,10 @@ function vendorPyodide() {
     name: "vendor-pyodide",
     buildStart() {
       const dest = resolve(__dirname, "public/pyodide");
-      if (!existsSync(dest)) {
-        cpSync(pyodideDir, dest, { recursive: true });
-      }
+      // Always refresh from the (postinstall-vendored, wheel-populated) node_modules/pyodide
+      // so the browser can loadPackage offline. A stale dest would silently lack wheels.
+      rmSync(dest, { recursive: true, force: true });
+      cpSync(pyodideDir, dest, { recursive: true });
     },
   };
 }

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: { fs: { allow: [".."] } },
+  test: {
+    globals: true,
+    // Node by default (Pyodide-in-Node keystone test); the component test opts into jsdom per-file.
+    environment: "node",
+    testTimeout: 120_000, // Pyodide boot + micropip install is slow on first run.
+    hookTimeout: 120_000,
+  },
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
   server: { fs: { allow: [".."] } },
   test: {
     globals: true,
+    // Only collect unit/component tests under src/. The Playwright e2e specs in e2e/
+    // are run by `playwright test`, not Vitest (their `test` import is incompatible).
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
     // Node by default (Pyodide-in-Node keystone test); the component test opts into jsdom per-file.
     environment: "node",
     testTimeout: 120_000, // Pyodide boot + micropip install is slow on first run.


### PR DESCRIPTION
## Summary

First sub-plan of the Streamlit -> fully-static browser-side (Pyodide/WASM) migration (epic #395). Keystone-first: proves the tested Python core `features/` runs UNMODIFIED inside a self-hosted browser Pyodide runtime and produces BYTE-IDENTICAL rendered output to CPython, behind a thin worker contract and a minimal React harness, enforced by CI. This de-risks all of P1 before the polished UI is built.

Closes #398. Refs #395.

Plan: `docs/superpowers/plans/2026-06-12-frontend-p1a-pyodide-bringup.md`

## What landed (8 tasks)

- **Scaffold** `web/` (Vite + React + TypeScript), isolated from the root Electron package.
- **Self-hosted Pyodide**: vendored from the npm `pyodide` package (the jsdelivr CDN is 403-blocked by the environment, so CDN independence is required, not optional). `features/*.py` are mounted into the Pyodide FS via a Vite `?raw` glob -- `features/` stays the single source of truth (not copied/forked).
- **Keystone proof** (`web/src/worker/pyodide-runtime.node.test.ts`): boots Pyodide on Node and asserts `features/` renders a CSV fixture to exactly `1:100\nN/A...` (matching the CPython golden in `tests/unit/test_config_parser.py::test_csv_render_layer_parity` -- ints stay ints, `N/A` stays a literal string per #396) plus a TOML fixture, plus config/template error paths. Real, discriminating assertions; no browser needed for this gate.
- **Worker contract** (`generate.worker.ts`): thin `init`/`generate`/`ready`/`error` postMessage protocol; the UI knows no Python, the worker knows no React.
- **Minimal React harness** (`App.tsx`): two textareas + output `<pre>` + error banner, 250ms debounce. Intentionally bare -- CodeMirror/drawers/samples/download are deferred (see below).
- **Playwright e2e** (`e2e/render-parity.spec.ts`): browser proof of the same render parity, asserted exactly via `textContent` (not whitespace-normalizing `toHaveText`).
- **CI** (`.github/workflows/web-ci.yml`): standalone, low-blast-radius. `web-test` runs the Vitest keystone as a BLOCKING gate on every PR. `web-e2e` is non-blocking for now (the Playwright browser CDN may be egress-restricted; promote to a hard gate once reachable).

## Supply-chain hardening

`web/scripts/vendor-pyodide-wheels.sh` (npm postinstall) provisions the wheels `features/` needs into the local Pyodide distribution so `loadPackage` resolves them OFFLINE (no CDN):

- The Pyodide release tarball is **sha256-pinned and verified BEFORE extraction** (`f6ee2096...`), fail-loud on mismatch.
- The chardet wheel is sha256-verified against the repo pin (`uv.lock`).
- The governance preflight tool `scripts/inspect_release_archive.sh` was extended to support `.tar.bz2` (the format Pyodide ships) so the mandated CLAUDE.local.md "Release-archive preflight" can actually run; the observed `pyodide/`-flat layout and `--strip-components=1` are documented from that inspection.
- A `python3` availability guard fails loudly if the lock-registration prerequisite is missing.

## Deferred to later sub-plans (NOT in P1a, by design)

CodeMirror 6 editors, drag-and-drop, settings drawer, samples menu, how-to modal, markdown/config-debug preview modes, client-side download, i18n catalog, and Vercel deployment + runbook. P1a uses plain textareas purely to exercise the worker end-to-end.

## Reviewer notes / known follow-ups

- The plan's separate `contract.test.ts` was intentionally folded into the keystone test file (config + template error cases) to avoid a second ~4s Pyodide boot (DRY). Coverage is present; a dedicated isolated contract test is a fine P1b follow-up.
- The keystone test uses a literal `N/A` cell (proving na-string preservation + no int->float promotion). The empty-cell fill path is already covered by the CPython unit tests; add a browser-side empty-cell case in P1b.
- The harness error banner currently shows any worker error in the config slot; fine for bring-up, to be refined when the error UI is built.

## Test plan

- [x] `cd web && npx vitest run` -> 2 files, 6 tests pass (keystone CSV+TOML render parity, error paths, component harness). e2e excluded from Vitest (run by Playwright).
- [x] `cd web && npm run build` -> static `dist/` with `dist/pyodide/` populated incl. the wasm wheels.
- [x] `cd web && npx tsc -b --noEmit` -> clean.
- [x] `scripts/inspect_release_archive.sh` verifies the pinned tarball sha256 + layout; vendor script verified (success + induced-mismatch failure).
- [ ] Browser e2e: UNVERIFIED LOCALLY (chromium CDN `cdn.playwright.dev` is 403-blocked here) -- to be exercised by CI / a maintainer with browser access. Honest per the verifiability standard; not faked.
- [ ] CI `web-test` keystone gate runs green on this PR (GitHub Actions).


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELmAFE6eGz6RDa5aETLTAS)_