### PR TITLE
ci: CI-parity pre-push gate to stop the recurring repair class (#403)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 minimum_pre_commit_version: "3.7.1" # pyproject.tomlと一致させる
-default_install_hook_types: [pre-commit, commit-msg]
+default_install_hook_types: [pre-commit, commit-msg, pre-push]
 default_stages: [pre-commit]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -180,4 +180,13 @@ repos:
         language: system
         pass_filenames: false
         types: [python]
+        verbose: true
+      - id: ci-parity
+        name: CI-parity gate (ruff/mypy/all-language lizard/web tsc+vitest)
+        description: "Mirror CI's fast blocking checks before push so repairs don't slip through (refs #403)."
+        entry: bash scripts/ci-parity.sh
+        language: system
+        stages: [pre-push]
+        pass_filenames: false
+        always_run: true
         verbose: true

--- a/scripts/ci-parity.sh
+++ b/scripts/ci-parity.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# CI-parity local gate. Refs #403 (recurring action from retrospectives #397, #401).
+#
+# Runs the CI BLOCKING checks that have actually caused PR repair churn, so the
+# "local verification did not mirror CI" failure class cannot recur. It mirrors,
+# in particular, two gates whose LOCAL form diverged from CI and let repairs through:
+#   - lizard CCN: CI scans ALL languages (incl. web TypeScript); the existing
+#     pre-commit `lizard_combined` hook is `-l python` only, so a TS CCN>10
+#     (App.tsx, PR #399) was invisible locally. This runs CI's all-language command.
+#   - web Vitest: there was NO local web gate at all; CI's whole-project
+#     `npx vitest run` collected the Playwright e2e spec and failed (PR #399).
+#
+# Deliberately NOT run here (kept to CI): the full `pytest -n auto` suite and the
+# desktop `npm run build`. They are slow / memory-heavy, are already enforced in CI
+# (and pytest is already a pre-commit hook), and have not caused a repair. This keeps
+# the gate fast and reliably runnable locally.
+#
+# Run manually: `bash scripts/ci-parity.sh`
+# Runs automatically on `git push` once installed: `pre-commit install --hook-type pre-push`
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+fail=0
+run() {
+  local label="$1"
+  shift
+  echo ""
+  echo "=== ci-parity: ${label} ==="
+  if "$@"; then
+    echo "PASS: ${label}"
+  else
+    echo "FAIL: ${label}" >&2
+    fail=1
+  fi
+}
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "ci-parity: required tool 'uv' not found (https://docs.astral.sh/uv/)" >&2
+  exit 2
+fi
+
+# --- Python gates (mirror CI 'Guard Python code quality' + 'Code Complexity') ---
+run "ruff check" uv run ruff check .
+run "mypy (whole project)" uv run mypy .
+# All-language lizard, matching CI (NO -l python). Extra excludes cover web build /
+# vendored Pyodide dirs that exist locally but not in CI's lizard job, so the local
+# scope matches CI's effective scope (production source only).
+run "lizard CCN<=10 (all languages)" uv run lizard \
+  -x './node_modules/*' -x './.venv/*' -x './build/*' -x './dist/*' \
+  -x './htmlcov/*' -x './tests/*' \
+  -x './web/node_modules/*' -x './web/dist/*' -x './web/public/*' \
+  --CCN 10
+
+# --- Web gates (mirror the web-ci Pyodide keystone job) ---
+if [ -d web/node_modules ]; then
+  run "web tsc" bash -c 'cd web && npx tsc -b --noEmit'
+  run "web vitest (whole project)" bash -c 'cd web && npx vitest run'
+else
+  echo "" >&2
+  echo "FAIL: web gates -- web/node_modules is missing. Run 'cd web && npm ci' first." >&2
+  fail=1
+fi
+
+echo ""
+if [ "${fail}" -ne 0 ]; then
+  echo "ci-parity: FAILED -- fix the above before pushing (CI gates on these)." >&2
+  exit 1
+fi
+echo "ci-parity: all gates passed."


### PR DESCRIPTION
## Summary

Retrospectives #397 (PR #396) and #401 (PR #399) found the SAME root cause twice: local verification did not mirror CI, so repairs were only caught after pushing. This lands the durable fix both retros prescribed -- a deterministic CI-parity local gate wired as a `pre-push` hook -- so currency is harness-enforced, not agent-remembered.

Closes #403. Refs #397, #401.

## The two gaps this closes (now confirmed in config)

- **lizard CCN on TypeScript:** the existing pre-commit `lizard_combined` hook runs `lizard -l python` (Python only) with `types: [python]`, so the App.tsx CCN 12 (TypeScript) in PR #399 was invisible locally and only failed in CI (whose lizard scans all languages).
- **web Vitest:** there was NO local web gate at all; CI's whole-project `npx vitest run` collected the Playwright e2e spec and failed in PR #399 (local per-task runs were file-scoped).

## What landed

- `scripts/ci-parity.sh` -- fail-fast, loud, runs the CI blocking checks that have caused repair churn:
  - `uv run ruff check .`
  - `uv run mypy .` (whole project)
  - `uv run lizard <CI excludes + web build/vendor dirs> --CCN 10` (ALL languages, matching CI -- this is what catches TS CCN)
  - `cd web && npx tsc -b --noEmit`
  - `cd web && npx vitest run` (whole project, not file-scoped)
- `.pre-commit-config.yaml` -- adds `pre-push` to `default_install_hook_types` and a `repo: local` `ci-parity` hook at `stages: [pre-push]`. Existing hooks are untouched (additive, low blast radius). Activate with `pre-commit install --hook-type pre-push` (already covered by a plain `pre-commit install` now that pre-push is a default hook type).

## Deliberate scope (kept to CI)

The gate does NOT run the full `pytest -n auto` suite or the desktop `npm run build` locally: those are slow / memory-heavy, are already enforced in CI (pytest is also already a pre-commit hook), and have not caused a repair. The gate covers exactly the fast static/type/complexity/web checks that DID cause repairs, so it stays fast and reliably runnable.

## Verification (regression-proofed the gate itself)

- Clean tree: all 5 gates PASS; the hook runs Green through `pre-commit run ci-parity --hook-stage pre-push`.
- Repair-class 1 (reintroduced: removed the Vitest `include` so e2e is collected) -> `FAIL: web vitest` -> script exits non-zero.
- Repair-class 2 (reintroduced: a CCN-13 TypeScript function) -> `FAIL: lizard` -> script exits non-zero.
- After reverting both: all gates pass again.

## Test plan

- [x] `bash scripts/ci-parity.sh` passes on a clean tree (ruff, mypy, lizard all-languages, web tsc, web vitest 6/6).
- [x] `pre-commit validate-config` clean; hook invokes correctly at the pre-push stage.
- [x] Gate fails loudly when either repair class is reintroduced (evidence above).
- [ ] CI green on this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELmAFE6eGz6RDa5aETLTAS)_