### PR TITLE
Frontend P1b-2: Text/Markdown sanitized live preview (#408)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "dompurify": "^3.2.4",
+        "marked": "^14.1.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -17,6 +19,7 @@
         "@codemirror/lang-yaml": "^6.1.2",
         "@playwright/test": "^1.56.1",
         "@testing-library/react": "^16.0.1",
+        "@types/dompurify": "^3.0.5",
         "@types/node": "^22.19.21",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -831,6 +834,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -875,6 +888,13 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@uiw/codemirror-extensions-basic-setup": {
       "version": "4.25.10",
@@ -1305,6 +1325,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -1964,6 +1993,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.4.tgz",
+      "integrity": "sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {

--- a/web/package.json
+++ b/web/package.json
@@ -13,10 +13,13 @@
     "e2e": "playwright test"
   },
   "dependencies": {
+    "dompurify": "^3.2.4",
+    "marked": "^14.1.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@types/dompurify": "^3.0.5",
     "@codemirror/lang-json": "^6.0.1",
     "@codemirror/lang-yaml": "^6.1.2",
     "@playwright/test": "^1.56.1",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import GenerateWorker from "./worker/generate.worker?worker";
 import type { WorkerOutbound, GenerateResult } from "./worker/types";
 import { DEFAULT_SETTINGS } from "./worker/types";
 import { Editor } from "./components/Editor";
+import { Preview, type PreviewMode } from "./components/Preview";
 
 const DEBOUNCE_MS = 250;
 
@@ -26,6 +27,7 @@ export function App() {
     "{% for r in csv_rows %}{{ r.id }}:{{ r.value }}\n{% endfor %}",
   );
   const [result, setResult] = useState<GenerateResult | null>(null);
+  const [previewMode, setPreviewMode] = useState<PreviewMode>("text");
 
   useEffect(() => {
     const worker = new GenerateWorker();
@@ -70,7 +72,11 @@ export function App() {
       <Editor ariaLabel="config" value={config} language="yaml" onChange={setConfig} />
       <Editor ariaLabel="template" value={template} language="plain" onChange={setTemplate} />
       {error !== null && <div role="alert">{error}</div>}
-      <pre>{viewOutput(result)}</pre>
+      <div role="group" aria-label="preview mode">
+        <button type="button" aria-pressed={previewMode === "text"} onClick={() => setPreviewMode("text")}>Text</button>
+        <button type="button" aria-pressed={previewMode === "markdown"} onClick={() => setPreviewMode("markdown")}>Markdown</button>
+      </div>
+      <Preview output={viewOutput(result)} mode={previewMode} />
     </main>
   );
 }

--- a/web/src/components/Preview.test.tsx
+++ b/web/src/components/Preview.test.tsx
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Preview } from "./Preview";
+
+describe("Preview", () => {
+  it("text mode shows raw output in a <pre>", () => {
+    render(<Preview output={"a\nb"} mode="text" />);
+    expect(document.querySelector("pre")?.textContent).toBe("a\nb");
+  });
+
+  it("markdown mode renders HTML tags", () => {
+    render(<Preview output={"# Title"} mode="markdown" />);
+    expect(screen.getByText("Title").tagName).toBe("H1");
+  });
+
+  it("markdown mode sanitizes dangerous markup", () => {
+    render(<Preview output={"<img src=x onerror=alert(1)>\n\n<script>alert(1)</script>"} mode="markdown" />);
+    const container = screen.getByTestId("markdown-preview");
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.innerHTML).not.toContain("onerror");
+  });
+});

--- a/web/src/components/Preview.tsx
+++ b/web/src/components/Preview.tsx
@@ -1,0 +1,17 @@
+import { marked } from "marked";
+import DOMPurify from "dompurify";
+
+export type PreviewMode = "text" | "markdown";
+
+interface PreviewProps {
+  output: string;
+  mode: PreviewMode;
+}
+
+export function Preview({ output, mode }: PreviewProps) {
+  if (mode === "markdown") {
+    const html = DOMPurify.sanitize(marked.parse(output, { async: false }) as string);
+    return <div data-testid="markdown-preview" dangerouslySetInnerHTML={{ __html: html }} />;
+  }
+  return <pre>{output}</pre>;
+}


### PR DESCRIPTION
## Summary

Second P1b increment. Adds a **Text/Markdown live-preview switch** to the command-generation view: the worker's `formatted_text` renders either as raw **Text** (`<pre>`) or as **sanitized Markdown** (`marked` -> `DOMPurify.sanitize`). Text is the default, so the render-parity keystone (asserting on `pre` text) is preserved.

Closes #408. Refs #395. Plan: `docs/superpowers/plans/2026-06-12-frontend-p1b-live-preview-ui.md` (P1b-2).

## What landed

- `web/src/components/Preview.tsx`: `{ output, mode }` -> `<pre>` for `text`; for `markdown`, `DOMPurify.sanitize(marked.parse(output, { async: false }))` injected into a `data-testid="markdown-preview"` div. Sanitizing the parsed HTML (not the raw markdown) is the correct order and strips active content.
- `web/src/App.tsx`: a `role="group"` Text/Markdown toggle (aria-pressed) bound to a `previewMode` state (default `text`); output pane uses `<Preview>`. Editors, worker/debounce, error banner unchanged.
- New web deps: `marked`, `dompurify` (+ `@types/dompurify`).

## Out of scope (later increments)

Settings drawer (P1b-3), samples menu + client-side download + i18n (P1b-4).

## Test plan

- [x] `bash scripts/ci-parity.sh` green (independently re-run): ruff, mypy ., all-language lizard --CCN 10 (Preview CCN 2), web tsc, whole-project vitest (11 tests / 4 files).
- [x] Security: the Preview test asserts a `<script>` / `onerror` payload is stripped by DOMPurify before injection.
- [x] `cd web && npm run build` emits `dist/`.
- [ ] CI green (incl. render-parity e2e -- default Text mode shows the seeded output).


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELmAFE6eGz6RDa5aETLTAS)_