### PR TITLE
Frontend P1b-4a: one-click sample injection menu (#412)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import { DEFAULT_SETTINGS } from "./worker/types";
 import { Editor } from "./components/Editor";
 import { Preview, type PreviewMode } from "./components/Preview";
 import { SettingsDrawer } from "./components/SettingsDrawer";
+import { SampleMenu } from "./components/SampleMenu";
 
 const DEBOUNCE_MS = 250;
 
@@ -71,6 +72,7 @@ export function App() {
     <main>
       <h1>Command Ghostwriter</h1>
       <p>{status}</p>
+      <SampleMenu onLoad={(c, t) => { setConfig(c); setTemplate(t); }} />
       <Editor ariaLabel="config" value={config} language="yaml" onChange={setConfig} />
       <Editor ariaLabel="template" value={template} language="plain" onChange={setTemplate} />
       {error !== null && <div role="alert">{error}</div>}

--- a/web/src/components/SampleMenu.test.tsx
+++ b/web/src/components/SampleMenu.test.tsx
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SampleMenu } from "./SampleMenu";
+
+describe("SampleMenu", () => {
+  it("clicking a sample loads non-empty config and template", () => {
+    const onLoad = vi.fn();
+    render(<SampleMenu onLoad={onLoad} />);
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.length).toBeGreaterThan(0);
+    fireEvent.click(buttons[0]);
+    expect(onLoad).toHaveBeenCalledTimes(1);
+    const [config, template] = onLoad.mock.calls[0];
+    expect(typeof config).toBe("string");
+    expect(config.length).toBeGreaterThan(0);
+    expect(template.length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/components/SampleMenu.tsx
+++ b/web/src/components/SampleMenu.tsx
@@ -1,0 +1,17 @@
+import { SAMPLES } from "../samples";
+
+interface SampleMenuProps {
+  onLoad: (config: string, template: string) => void;
+}
+
+export function SampleMenu({ onLoad }: SampleMenuProps) {
+  return (
+    <div role="group" aria-label="samples">
+      {SAMPLES.map((s) => (
+        <button key={s.label} type="button" onClick={() => onLoad(s.config, s.template)}>
+          {s.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/src/samples.ts
+++ b/web/src/samples.ts
@@ -1,0 +1,23 @@
+const raw = import.meta.glob("../../assets/examples/*.{toml,yaml,yml,csv,j2,jinja2}", {
+  query: "?raw",
+  eager: true,
+  import: "default",
+}) as Record<string, string>;
+
+function byName(filename: string): string {
+  const entry = Object.entries(raw).find(([key]) => key.endsWith("/" + filename));
+  if (entry === undefined) throw new Error(`sample not found: ${filename}`);
+  return entry[1];
+}
+
+export interface Sample {
+  label: string;
+  config: string;
+  template: string;
+}
+
+export const SAMPLES: Sample[] = [
+  { label: "Cisco", config: byName("cisco_config.toml"), template: byName("cisco_template.jinja2") },
+  { label: "DNS dig", config: byName("dns_dig_config.csv"), template: byName("dns_dig_tmpl.j2") },
+  { label: "Success", config: byName("success_config.yaml"), template: byName("success_template.j2") },
+];


### PR DESCRIPTION
## Summary

P1b-4a: one-click **sample injection** menu. Loads a bundled example config+template pair into the editors (replaces old Streamlit tab4). First of three final P1b increments.

Closes #412. Refs #395. Plan: `docs/superpowers/plans/2026-06-12-frontend-p1b-live-preview-ui.md` (P1b-4).

## What landed

- `web/src/samples.ts`: loads `assets/examples/*` as raw strings via Vite `import.meta.glob` (single source of truth, like `features-sources.ts` -- no copy/fork); exports `SAMPLES` pairing config+template (Cisco / DNS dig / Success). `byName` throws loudly if a file is missing.
- `web/src/components/SampleMenu.tsx`: one button per sample; click -> `onLoad(config, template)`.
- `web/src/App.tsx`: renders `<SampleMenu onLoad={(c, t) => { setConfig(c); setTemplate(t); }} />` above the editors.

## Out of scope

Client-side download (P1b-4b), i18n catalog (P1b-4c).

## Test plan

- [x] `bash scripts/ci-parity.sh` green (independently re-run): ruff, mypy ., all-language lizard --CCN 10 (SampleMenu CCN 1, byName CCN 2), web tsc, whole-project vitest (15 tests / 6 files incl. a SampleMenu test: clicking a sample calls `onLoad` with two non-empty strings -- real example content bundled by the glob).
- [x] `cd web && npm run build` emits `dist/` (glob inlines the example text).
- [ ] CI green (render-parity e2e unaffected; defaults unchanged).


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELmAFE6eGz6RDa5aETLTAS)_