### PR TITLE
Frontend P1b-4b: client-side download (Blob) (#414)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { Editor } from "./components/Editor";
 import { Preview, type PreviewMode } from "./components/Preview";
 import { SettingsDrawer } from "./components/SettingsDrawer";
 import { SampleMenu } from "./components/SampleMenu";
+import { DownloadBar } from "./components/DownloadBar";
 
 const DEBOUNCE_MS = 250;
 
@@ -82,6 +83,7 @@ export function App() {
         <button type="button" aria-pressed={previewMode === "markdown"} onClick={() => setPreviewMode("markdown")}>Markdown</button>
       </div>
       <Preview output={viewOutput(result)} mode={previewMode} />
+      <DownloadBar output={viewOutput(result)} />
     </main>
   );
 }

--- a/web/src/components/DownloadBar.tsx
+++ b/web/src/components/DownloadBar.tsx
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import { downloadFilename, triggerDownload } from "../download";
+
+interface DownloadBarProps {
+  output: string;
+}
+
+export function DownloadBar({ output }: DownloadBarProps) {
+  const [name, setName] = useState("command");
+  const [ext, setExt] = useState("txt");
+  const [appendTimestamp, setAppendTimestamp] = useState(true);
+
+  function handleDownload() {
+    triggerDownload(output, downloadFilename(name, ext, appendTimestamp));
+  }
+
+  return (
+    <div role="group" aria-label="download">
+      <input aria-label="downloadName" type="text" value={name} onChange={(e) => setName(e.target.value)} />
+      <select aria-label="downloadExt" value={ext} onChange={(e) => setExt(e.target.value)}>
+        <option value="txt">txt</option>
+        <option value="md">md</option>
+      </select>
+      <label>
+        <input aria-label="appendTimestamp" type="checkbox" checked={appendTimestamp} onChange={(e) => setAppendTimestamp(e.target.checked)} />
+        タイムスタンプ付与
+      </label>
+      <button type="button" disabled={output.length === 0} onClick={handleDownload}>ダウンロード</button>
+    </div>
+  );
+}

--- a/web/src/download.test.ts
+++ b/web/src/download.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { downloadFilename } from "./download";
+
+describe("downloadFilename", () => {
+  it("no timestamp -> name.ext", () => {
+    expect(downloadFilename("command", "txt", false)).toBe("command.txt");
+  });
+  it("with timestamp -> dated suffix (YYYY-MM-DD_HHMMSS)", () => {
+    const d = new Date(2026, 5, 12, 9, 8, 7); // month is 0-indexed: 5 = June -> 2026-06-12_090807
+    expect(downloadFilename("out", "md", true, d)).toBe("out_2026-06-12_090807.md");
+  });
+});

--- a/web/src/download.ts
+++ b/web/src/download.ts
@@ -1,0 +1,19 @@
+function timestamp(date: Date): string {
+  const p = (n: number): string => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${p(date.getMonth() + 1)}-${p(date.getDate())}_${p(date.getHours())}${p(date.getMinutes())}${p(date.getSeconds())}`;
+}
+
+export function downloadFilename(name: string, ext: string, appendTimestamp: boolean, now: Date = new Date()): string {
+  const suffix = appendTimestamp ? `_${timestamp(now)}` : "";
+  return `${name}${suffix}.${ext}`;
+}
+
+export function triggerDownload(text: string, filename: string): void {
+  const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary

P1b-4b: client-side **download** of the generated output as a utf-8 Blob, with filename / extension / timestamp options (download half of old Streamlit tab3). Second of the three final P1b increments.

Closes #414. Refs #395. Plan: `docs/superpowers/plans/2026-06-12-frontend-p1b-live-preview-ui.md` (P1b-4).

## What landed

- `web/src/download.ts`: `downloadFilename(name, ext, appendTimestamp, now?)` (matches AppCore's `YYYY-MM-DD_HHMMSS` suffix; injectable `now` for deterministic tests) + `triggerDownload(text, filename)` (utf-8 Blob + anchor click + revoke).
- `web/src/components/DownloadBar.tsx`: filename input, txt/md selector, append-timestamp checkbox, Download button (disabled when output is empty). CCN 1.
- `web/src/App.tsx`: renders `<DownloadBar output={viewOutput(result)} />` below the preview.

## Deferred

Encoding selector (Shift_JIS): browser `TextEncoder` only emits utf-8; Shift_JIS download will route through the worker's Python encoder under P2 "full settings parity". i18n catalog is P1b-4c (next).

## Test plan

- [x] `bash scripts/ci-parity.sh` green (independently re-run): ruff, mypy ., all-language lizard --CCN 10 (download.ts / DownloadBar CCN 1), web tsc, whole-project vitest (17 tests / 7 files incl. a `downloadFilename` test: `command.txt` without timestamp; `out_2026-06-12_090807.md` with a fixed date).
- [x] `cd web && npm run build` emits `dist/`.
- [ ] CI green (render-parity e2e unaffected).


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELmAFE6eGz6RDa5aETLTAS)_