### PR TITLE
Frontend P1b-4c: i18n label catalog -- completes P1b (#416)

### DIFF
--- a/web/e2e/render-parity.spec.ts
+++ b/web/e2e/render-parity.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 test("renders the CSV+Jinja fixture in a real browser", async ({ page }) => {
   await page.goto("/");
   // Wait for Pyodide to finish booting in the worker.
-  await expect(page.getByText("ready")).toBeVisible({ timeout: 180_000 });
+  await expect(page.getByText("準備完了")).toBeVisible({ timeout: 180_000 });
   // App seeds the same fixture as the Node keystone test; assert byte-identical output
   // (textContent, not toHaveText, to preserve the exact newlines).
   await expect

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { Preview, type PreviewMode } from "./components/Preview";
 import { SettingsDrawer } from "./components/SettingsDrawer";
 import { SampleMenu } from "./components/SampleMenu";
 import { DownloadBar } from "./components/DownloadBar";
+import { t } from "./i18n";
 
 const DEBOUNCE_MS = 250;
 
@@ -67,11 +68,11 @@ export function App() {
   }, [config, template, ready, settings]);
 
   const error = viewError(result);
-  const status = ready ? "ready" : "loading Pyodide...";
+  const status = ready ? t.ready : t.loading;
 
   return (
     <main>
-      <h1>Command Ghostwriter</h1>
+      <h1>{t.appTitle}</h1>
       <p>{status}</p>
       <SampleMenu onLoad={(c, t) => { setConfig(c); setTemplate(t); }} />
       <Editor ariaLabel="config" value={config} language="yaml" onChange={setConfig} />
@@ -79,8 +80,8 @@ export function App() {
       {error !== null && <div role="alert">{error}</div>}
       <SettingsDrawer settings={settings} onChange={setSettings} />
       <div role="group" aria-label="preview mode">
-        <button type="button" aria-pressed={previewMode === "text"} onClick={() => setPreviewMode("text")}>Text</button>
-        <button type="button" aria-pressed={previewMode === "markdown"} onClick={() => setPreviewMode("markdown")}>Markdown</button>
+        <button type="button" aria-pressed={previewMode === "text"} onClick={() => setPreviewMode("text")}>{t.previewText}</button>
+        <button type="button" aria-pressed={previewMode === "markdown"} onClick={() => setPreviewMode("markdown")}>{t.previewMarkdown}</button>
       </div>
       <Preview output={viewOutput(result)} mode={previewMode} />
       <DownloadBar output={viewOutput(result)} />

--- a/web/src/components/DownloadBar.tsx
+++ b/web/src/components/DownloadBar.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { downloadFilename, triggerDownload } from "../download";
+import { t } from "../i18n";
 
 interface DownloadBarProps {
   output: string;
@@ -23,9 +24,9 @@ export function DownloadBar({ output }: DownloadBarProps) {
       </select>
       <label>
         <input aria-label="appendTimestamp" type="checkbox" checked={appendTimestamp} onChange={(e) => setAppendTimestamp(e.target.checked)} />
-        タイムスタンプ付与
+        {t.appendTimestamp}
       </label>
-      <button type="button" disabled={output.length === 0} onClick={handleDownload}>ダウンロード</button>
+      <button type="button" disabled={output.length === 0} onClick={handleDownload}>{t.download}</button>
     </div>
   );
 }

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -1,4 +1,5 @@
 import type { GenerateSettings } from "../worker/types";
+import { t } from "../i18n";
 
 const FORMAT_TYPE_LABELS: Record<number, string> = {
   0: "フォーマット指定無し",
@@ -20,21 +21,21 @@ export function SettingsDrawer({ settings, onChange }: SettingsDrawerProps) {
 
   return (
     <details>
-      <summary>詳細設定</summary>
+      <summary>{t.settingsTitle}</summary>
       <label>
-        CSV行の変数名
+        {t.csvRowsName}
         <input aria-label="csvRowsName" type="text" value={settings.csvRowsName} onChange={(e) => set("csvRowsName", e.target.value)} />
       </label>
       <label>
         <input aria-label="enableFillNan" type="checkbox" checked={settings.enableFillNan} onChange={(e) => set("enableFillNan", e.target.checked)} />
-        CSVの欠損値を指定文字で埋める
+        {t.enableFillNan}
       </label>
       <label>
-        欠損値の変換文字
+        {t.fillNanWith}
         <input aria-label="fillNanWith" type="text" value={settings.fillNanWith} onChange={(e) => set("fillNanWith", e.target.value)} />
       </label>
       <label>
-        出力フォーマット
+        {t.formatType}
         <select aria-label="formatType" value={settings.formatType} onChange={(e) => set("formatType", Number(e.target.value))}>
           {[0, 1, 2, 3, 4].map((n) => (
             <option key={n} value={n}>{FORMAT_TYPE_LABELS[n]}</option>
@@ -43,11 +44,11 @@ export function SettingsDrawer({ settings, onChange }: SettingsDrawerProps) {
       </label>
       <label>
         <input aria-label="isStrictUndefined" type="checkbox" checked={settings.isStrictUndefined} onChange={(e) => set("isStrictUndefined", e.target.checked)} />
-        テンプレートの変数チェック厳格化
+        {t.isStrictUndefined}
       </label>
       <label>
         <input aria-label="enableAutoTranscoding" type="checkbox" checked={settings.enableAutoTranscoding} onChange={(e) => set("enableAutoTranscoding", e.target.checked)} />
-        UTF-8以外の文字コードを自動判定
+        {t.enableAutoTranscoding}
       </label>
     </details>
   );

--- a/web/src/i18n.test.ts
+++ b/web/src/i18n.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { t } from "./i18n";
+
+describe("i18n catalog", () => {
+  it("has populated Japanese labels", () => {
+    expect(t.download).toBe("ダウンロード");
+    expect(t.settingsTitle).toBe("詳細設定");
+    for (const value of Object.values(t)) {
+      expect(typeof value).toBe("string");
+      expect(value.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -1,0 +1,16 @@
+export const t = {
+  appTitle: "Command Ghostwriter",
+  loading: "Pyodideを読み込み中...",
+  ready: "準備完了",
+  previewText: "テキスト",
+  previewMarkdown: "Markdown",
+  settingsTitle: "詳細設定",
+  csvRowsName: "CSV行の変数名",
+  enableFillNan: "CSVの欠損値を指定文字で埋める",
+  fillNanWith: "欠損値の変換文字",
+  formatType: "出力フォーマット",
+  isStrictUndefined: "テンプレートの変数チェック厳格化",
+  enableAutoTranscoding: "UTF-8以外の文字コードを自動判定",
+  appendTimestamp: "タイムスタンプ付与",
+  download: "ダウンロード",
+} as const;


### PR DESCRIPTION
## Summary

P1b-4c (final P1b increment): centralizes UI labels into a **Japanese i18n catalog** (`web/src/i18n.ts`), replacing hardcoded strings across the components. This completes the P1b live-preview UI on the P1a Pyodide bring-up.

Closes #416. Refs #395. Plan: `docs/superpowers/plans/2026-06-12-frontend-p1b-live-preview-ui.md` (P1b-4).

## What landed

- `web/src/i18n.ts`: a flat `t` catalog (14 Japanese labels) sourced from the repo `i18n.py` wording -- app title, loading/ready status, preview Text/Markdown, settings-drawer field labels, download-bar labels.
- `App.tsx`, `SettingsDrawer.tsx`, `DownloadBar.tsx`: visible labels now reference `t.*`. **No `aria-label` changed** (they are stable test identifiers; verified the diff touches none).
- `web/e2e/render-parity.spec.ts`: the status text became Japanese (`t.ready` = `準備完了`), so the e2e's ready-wait was updated `getByText("ready")` -> `getByText("準備完了")` to keep the render-parity proof passing in CI.

## Test plan

- [x] `bash scripts/ci-parity.sh` green (independently re-run): ruff, mypy ., all-language lizard --CCN 10, web tsc, whole-project vitest (18 tests / 8 files incl. an i18n catalog test).
- [x] `cd web && npm run build` emits `dist/`.
- [x] Existing component tests unaffected (they query aria-labels / roles / output text, not the visible labels).
- [ ] CI green, incl. the render-parity e2e with the updated ready label (Playwright is CI-only here -- the local chromium CDN is blocked).

## P1b complete

With this increment, P1b delivers the full live-preview UX on the proven worker: CodeMirror editors + drag-and-drop (#406), Text/Markdown sanitized preview (#409), settings drawer (#411), sample injection (#413), client-side download (#415), and this i18n catalog. Deferred to P2: config-debug view, how-to modal, Shift_JIS download, full settings parity; and Vercel deploy.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELmAFE6eGz6RDa5aETLTAS)_