### PR TITLE
Frontend P2-2: how-to / workflow modal (#421)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { Preview, type PreviewMode } from "./components/Preview";
 import { SettingsDrawer } from "./components/SettingsDrawer";
 import { SampleMenu } from "./components/SampleMenu";
 import { DownloadBar } from "./components/DownloadBar";
+import { HowToModal } from "./components/HowToModal";
 import { t } from "./i18n";
 
 const DEBOUNCE_MS = 250;
@@ -73,6 +74,7 @@ export function App() {
   return (
     <main>
       <h1>{t.appTitle}</h1>
+      <HowToModal />
       <p>{status}</p>
       <SampleMenu onLoad={(c, t) => { setConfig(c); setTemplate(t); }} />
       <Editor ariaLabel="config" value={config} language="yaml" onChange={setConfig} />

--- a/web/src/components/HowToModal.test.tsx
+++ b/web/src/components/HowToModal.test.tsx
@@ -1,0 +1,15 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { HowToModal } from "./HowToModal";
+
+describe("HowToModal", () => {
+  it("is hidden initially, opens on click, and closes", () => {
+    render(<HowToModal />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "使い方" }));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "閉じる" }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/web/src/components/HowToModal.tsx
+++ b/web/src/components/HowToModal.tsx
@@ -1,0 +1,19 @@
+import { useState } from "react";
+import workflowSvg from "../../../assets/images/workflow_sequence_diagram_jp.svg?url";
+import { t } from "../i18n";
+
+export function HowToModal() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>{t.howTo}</button>
+      {open && (
+        <div role="dialog" aria-label={t.howToDialog}>
+          <img src={workflowSvg} alt={t.howToDialog} />
+          <p>{t.howToText}</p>
+          <button type="button" onClick={() => setOpen(false)}>{t.close}</button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -14,4 +14,8 @@ export const t = {
   enableAutoTranscoding: "UTF-8以外の文字コードを自動判定",
   appendTimestamp: "タイムスタンプ付与",
   download: "ダウンロード",
+  howTo: "使い方",
+  howToDialog: "使い方の説明",
+  howToText: "設定定義ファイル(toml/yaml/csv)とJinjaテンプレートを各エディタに入力すると、リアルタイムにコマンドが生成されます。サンプルから読み込むこともできます。",
+  close: "閉じる",
 } as const;

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary

P2-2: a **how-to / workflow modal** (old Streamlit tab5). A "使い方" button opens a modal showing the workflow diagram SVG and a short usage note. Second of three P2 increments.

Closes #421. Refs #395. Plan: `docs/superpowers/plans/2026-06-12-frontend-p2-parity.md` (P2-2).

## What landed

- `web/src/components/HowToModal.tsx`: a "使い方" button opens a `role="dialog"` modal with the workflow SVG (imported via Vite `?url` from `assets/images/workflow_sequence_diagram_jp.svg` -- single source of truth, bundled as a 31 kB asset) + a usage paragraph + a close button. CCN 1.
- `web/src/i18n.ts`: `howTo` / `howToDialog` / `howToText` / `close` labels (Japanese, reflecting the editor-based UX).
- `web/src/vite-env.d.ts`: `/// <reference types="vite/client" />` for the `?url` import type.
- `web/src/App.tsx`: renders `<HowToModal />` after the title.

## Out of scope

Live mermaid rendering (static SVG used); Shift_JIS download + settings parity (P2-3, final).

## Test plan

- [x] `bash scripts/ci-parity.sh` green (independently re-run): ruff, mypy ., all-language lizard --CCN 10 (HowToModal CCN 1), web tsc, whole-project vitest (21 tests / 9 files incl. a HowToModal test: hidden initially, opens on click, closes).
- [x] `cd web && npm run build` emits `dist/` with the SVG bundled (`dist/assets/workflow_sequence_diagram_jp-*.svg`).
- [ ] CI green (render-parity e2e unaffected).


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELmAFE6eGz6RDa5aETLTAS)_