### PR TITLE
Frontend P2-1b: YAML/TOML config-debug views (#425)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,9 +11,11 @@
       "dependencies": {
         "dompurify": "^3.2.4",
         "encoding-japanese": "^2.2.0",
+        "js-yaml": "^4.1.0",
         "marked": "^14.1.4",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "smol-toml": "^1.3.1"
       },
       "devDependencies": {
         "@codemirror/lang-json": "^6.0.1",
@@ -22,6 +24,7 @@
         "@testing-library/react": "^16.0.1",
         "@types/dompurify": "^3.0.5",
         "@types/encoding-japanese": "^2.2.1",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.19.21",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -860,6 +863,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
@@ -1133,6 +1143,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -1677,6 +1693,28 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsdom": {
       "version": "25.0.1",
@@ -2354,6 +2392,18 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/web/package.json
+++ b/web/package.json
@@ -15,9 +15,11 @@
   "dependencies": {
     "dompurify": "^3.2.4",
     "encoding-japanese": "^2.2.0",
+    "js-yaml": "^4.1.0",
     "marked": "^14.1.4",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "smol-toml": "^1.3.1"
   },
   "devDependencies": {
     "@codemirror/lang-json": "^6.0.1",
@@ -25,6 +27,7 @@
     "@playwright/test": "^1.56.1",
     "@testing-library/react": "^16.0.1",
     "@types/dompurify": "^3.0.5",
+    "@types/js-yaml": "^4.0.9",
     "@types/encoding-japanese": "^2.2.1",
     "@types/node": "^22.19.21",
     "@types/react": "^18.3.12",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,8 @@ import GenerateWorker from "./worker/generate.worker?worker";
 import type { WorkerOutbound, GenerateResult, GenerateSettings } from "./worker/types";
 import { DEFAULT_SETTINGS } from "./worker/types";
 import { Editor } from "./components/Editor";
-import { Preview, type PreviewMode } from "./components/Preview";
+import { Preview } from "./components/Preview";
+import { ConfigDebug } from "./components/ConfigDebug";
 import { SettingsDrawer } from "./components/SettingsDrawer";
 import { SampleMenu } from "./components/SampleMenu";
 import { DownloadBar } from "./components/DownloadBar";
@@ -32,7 +33,7 @@ export function App() {
     "{% for r in csv_rows %}{{ r.id }}:{{ r.value }}\n{% endfor %}",
   );
   const [result, setResult] = useState<GenerateResult | null>(null);
-  const [previewMode, setPreviewMode] = useState<PreviewMode>("text");
+  const [previewMode, setPreviewMode] = useState<"text" | "markdown" | "config">("text");
   const [settings, setSettings] = useState<GenerateSettings>(DEFAULT_SETTINGS);
 
   useEffect(() => {
@@ -86,7 +87,11 @@ export function App() {
         <button type="button" aria-pressed={previewMode === "markdown"} onClick={() => setPreviewMode("markdown")}>{t.previewMarkdown}</button>
         <button type="button" aria-pressed={previewMode === "config"} onClick={() => setPreviewMode("config")}>{t.previewConfig}</button>
       </div>
-      <Preview output={previewMode === "config" ? (result?.configDebug ?? "") : viewOutput(result)} mode={previewMode} />
+      {previewMode === "config" ? (
+        <ConfigDebug json={result?.configDebug ?? ""} />
+      ) : (
+        <Preview output={viewOutput(result)} mode={previewMode} />
+      )}
       <DownloadBar output={viewOutput(result)} />
     </main>
   );

--- a/web/src/components/ConfigDebug.test.tsx
+++ b/web/src/components/ConfigDebug.test.tsx
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConfigDebug } from "./ConfigDebug";
+
+describe("ConfigDebug", () => {
+  it("shows JSON by default and re-serializes to YAML and TOML", () => {
+    render(<ConfigDebug json={'{"a": 1}'} />);
+    expect(screen.getByTestId("config-debug").textContent).toBe('{"a": 1}');
+    fireEvent.click(screen.getByRole("button", { name: "yaml" }));
+    expect(screen.getByTestId("config-debug").textContent).toContain("a: 1");
+    fireEvent.click(screen.getByRole("button", { name: "toml" }));
+    expect(screen.getByTestId("config-debug").textContent).toContain("a = 1");
+  });
+
+  it("shows a loud error instead of crashing on non-JSON input", () => {
+    render(<ConfigDebug json={"{not json"} />);
+    fireEvent.click(screen.getByRole("button", { name: "yaml" }));
+    expect(screen.getByTestId("config-debug").textContent).toContain("failed");
+  });
+});

--- a/web/src/components/ConfigDebug.tsx
+++ b/web/src/components/ConfigDebug.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import yaml from "js-yaml";
+import { stringify as tomlStringify } from "smol-toml";
+
+type ConfigFormat = "json" | "yaml" | "toml";
+
+function serialize(json: string, format: ConfigFormat): string {
+  if (json === "") return "";
+  if (format === "json") return json;
+  const obj = JSON.parse(json);
+  return format === "yaml" ? yaml.dump(obj) : tomlStringify(obj);
+}
+
+export function ConfigDebug({ json }: { json: string }) {
+  const [format, setFormat] = useState<ConfigFormat>("json");
+  let text: string;
+  try {
+    text = serialize(json, format);
+  } catch (err) {
+    text = `(${format} serialization failed: ${err instanceof Error ? err.message : String(err)})`;
+  }
+  return (
+    <div>
+      <div role="group" aria-label="config format">
+        {(["json", "yaml", "toml"] as ConfigFormat[]).map((f) => (
+          <button key={f} type="button" aria-pressed={format === f} onClick={() => setFormat(f)}>
+            {f}
+          </button>
+        ))}
+      </div>
+      <pre data-testid="config-debug">{text}</pre>
+    </div>
+  );
+}

--- a/web/src/components/Preview.test.tsx
+++ b/web/src/components/Preview.test.tsx
@@ -21,8 +21,4 @@ describe("Preview", () => {
     expect(container.innerHTML).not.toContain("onerror");
   });
 
-  it("config mode shows the debug string in a pre", () => {
-    render(<Preview output={'{"a": 1}'} mode="config" />);
-    expect(screen.getByTestId("config-debug").textContent).toBe('{"a": 1}');
-  });
 });

--- a/web/src/components/Preview.tsx
+++ b/web/src/components/Preview.tsx
@@ -1,7 +1,7 @@
 import { marked } from "marked";
 import DOMPurify from "dompurify";
 
-export type PreviewMode = "text" | "markdown" | "config";
+export type PreviewMode = "text" | "markdown";
 
 interface PreviewProps {
   output: string;
@@ -9,9 +9,6 @@ interface PreviewProps {
 }
 
 export function Preview({ output, mode }: PreviewProps) {
-  if (mode === "config") {
-    return <pre data-testid="config-debug">{output}</pre>;
-  }
   if (mode === "markdown") {
     const html = DOMPurify.sanitize(marked.parse(output, { async: false }) as string);
     return <div data-testid="markdown-preview" dangerouslySetInnerHTML={{ __html: html }} />;


### PR DESCRIPTION
## Summary

P2-1b: add **YAML and TOML views** to the config-debug panel (P2-1 had JSON only). A new `ConfigDebug` component re-serializes the parsed config (the worker's `configDebug` JSON string) into JSON / YAML / TOML via a format toggle. UI-only; no worker change.

Closes #425. Refs #395. Plan: `docs/superpowers/plans/2026-06-12-frontend-p2-parity.md` (P2-1b).

## What landed

- `web/src/components/ConfigDebug.tsx`: a JSON/YAML/TOML sub-toggle. JSON shows the `configDebug` string as-is; YAML/TOML do `JSON.parse(configDebug)` then `js-yaml.dump` / `smol-toml.stringify`. A try/catch renders a loud `(format serialization failed: ...)` message instead of crashing (e.g. a CSV with unfilled `NaN`, which is not strict JSON -- an uncommon edge case since `enableFillNan` defaults to true; the JSON view always works).
- `web/src/components/Preview.tsx`: `PreviewMode` reverted to `"text" | "markdown"` (config display moved to `ConfigDebug`); the obsolete Preview config test removed.
- `web/src/App.tsx`: in `config` mode renders `<ConfigDebug>`, else `<Preview>` (TS narrows `previewMode` to `"text" | "markdown"` in the else branch).
- New deps: `js-yaml` + `@types/js-yaml`, `smol-toml`.

## Test plan

- [x] `bash scripts/ci-parity.sh` green (independently re-run): ruff, mypy ., all-language lizard --CCN 10 (ConfigDebug serialize CCN 4), web tsc, whole-project vitest (24 tests incl. a ConfigDebug test: JSON default, YAML `a: 1` / TOML `a = 1` re-serialization, and a loud error on non-JSON input).
- [x] `cd web && npm run build` emits `dist/`.
- [ ] CI green (render-parity e2e unaffected; Text default).

## P2 fully complete

This finishes the optional P2-1b follow-up, so P2 now delivers config-debug JSON/YAML/TOML (#419 + this), how-to/workflow modal (#422), and full settings parity incl. Shift_JIS download (#424). Remaining migration work: P3 (test migration + remove Streamlit) and the Vercel deploy.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELmAFE6eGz6RDa5aETLTAS)_