### PR TITLE
ci: sync CLAUDE.md from tvna/claude-md master via scheduled workflow (#427)

### DIFF
--- a/.github/workflows/sync-claude-md.yml
+++ b/.github/workflows/sync-claude-md.yml
@@ -1,0 +1,85 @@
+# ============================================================
+# Workflow Information: sync-claude-md.yml
+# ============================================================
+#
+# 目的 (Purpose):
+# ---------------
+# エージェント指示の正本リポジトリ tvna/claude-md の CLAUDE.md を取得し、
+# 本リポジトリの CLAUDE.md (コミット済み実ファイル) へ追従させる。
+# 差分があれば PR を作成/更新する (レビュー必須・自動マージしない)。
+#
+# 方式の根拠 (Rationale):
+# -----------------------
+# - submodule + symlink は web 環境の fresh clone で壊れる (submodule は親clone
+#   に含まれない) ため、コミット済み実ファイルとして同期する。
+# - CLAUDE.md 変更をトリガにする CI は無いため GITHUB_TOKEN のみで足りる (PAT 不要)。
+# - リポジトリ設定で "Allow GitHub Actions to create and approve pull requests"
+#   を有効化しておくこと。
+#
+# 関連 (Reference):
+# -----------------
+# - Issue #427
+# - 設計書 docs/superpowers/specs/2026-06-13-claude-md-master-sync-design.md
+# ============================================================
+---
+name: Sync CLAUDE.md from master
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-claude-md-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync CLAUDE.md from tvna/claude-md
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Check out this repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Check out master CLAUDE.md
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: tvna/claude-md
+          ref: main
+          sparse-checkout: CLAUDE.md
+          sparse-checkout-cone-mode: false
+          path: .upstream-claude-md
+
+      - name: Copy master CLAUDE.md into place
+        run: |
+          cp .upstream-claude-md/CLAUDE.md CLAUDE.md
+          rm -rf .upstream-claude-md
+
+      - name: Create or update pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: main
+          branch: chore/sync-claude-md
+          delete-branch: true
+          commit-message: "chore: sync CLAUDE.md from tvna/claude-md (#427)"
+          title: "chore: sync CLAUDE.md from tvna/claude-md master"
+          body: |
+            Automated sync of `CLAUDE.md` from the master repository
+            [`tvna/claude-md`](https://github.com/tvna/claude-md) (`main`).
+
+            Source of truth is `tvna/claude-md`. Review required; do not auto-merge.
+
+            Refs #427

--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -25,3 +25,15 @@ is overwritten on every regeneration.
   `--strip-components`, member paths) in the code and its comments. Never
   write extraction paths from assumption; the apm nested-directory failure on
   PR #391 (exit 127) is the bug class this prevents. Refs #392, #393.
+
+## CLAUDE.md is sourced from the master repo
+
+- `CLAUDE.md` is synced from the master repository
+  [`tvna/claude-md`](https://github.com/tvna/claude-md) by
+  `.github/workflows/sync-claude-md.yml` (weekly + manual), landing via a
+  review PR. The master is the source of truth.
+- Do **not** run `apm compile` to regenerate `CLAUDE.md` locally; the sync
+  workflow is its sole owner. The local `.apm/instructions/` source is vestigial
+  for `CLAUDE.md` (it still drives superpowers skill deployment). Removing it and
+  regenerating `apm.lock.yaml` is deferred to a follow-up in an apm-capable
+  environment. Refs #427.

--- a/docs/superpowers/plans/2026-06-13-claude-md-master-sync.md
+++ b/docs/superpowers/plans/2026-06-13-claude-md-master-sync.md
@@ -1,0 +1,195 @@
+# CLAUDE.md Master-Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a scheduled GitHub Actions workflow that syncs `CLAUDE.md` from the master repo `tvna/claude-md` and opens a PR on changes.
+
+**Architecture:** A weekly + manually-dispatchable workflow checks out `tvna/claude-md` (sparse: `CLAUDE.md`), copies it over the repo's committed `CLAUDE.md`, and uses `peter-evans/create-pull-request` to open/update a review PR. `CLAUDE.md` stays a committed real file (fresh-clone safe). No submodule, no symlink. APM is left untouched (apm CLI unavailable in this environment).
+
+**Tech Stack:** GitHub Actions, `actions/checkout`, `step-security/harden-runner`, `peter-evans/create-pull-request`, `actionlint`.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-claude-md-master-sync-design.md` — **Issue #427**
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `.github/workflows/sync-claude-md.yml` | The sync workflow (only behavioral change) |
+| `CLAUDE.local.md` | Document that `CLAUDE.md` is upstream-owned and `apm compile` must not regenerate it |
+
+Out of scope (do NOT touch): `.apm/instructions/`, `apm.lock.yaml`, `CLAUDE.md` itself
+(the first sync PR updates `CLAUDE.md`; this plan does not).
+
+---
+
+### Task 1: Add the sync workflow
+
+**Files:**
+- Create: `.github/workflows/sync-claude-md.yml`
+
+- [ ] **Step 1: Create the workflow file**
+
+Create `.github/workflows/sync-claude-md.yml` with exactly this content:
+
+```yaml
+# ============================================================
+# Workflow Information: sync-claude-md.yml
+# ============================================================
+#
+# 目的 (Purpose):
+# ---------------
+# エージェント指示の正本リポジトリ tvna/claude-md の CLAUDE.md を取得し、
+# 本リポジトリの CLAUDE.md (コミット済み実ファイル) へ追従させる。
+# 差分があれば PR を作成/更新する (レビュー必須・自動マージしない)。
+#
+# 方式の根拠 (Rationale):
+# -----------------------
+# - submodule + symlink は web 環境の fresh clone で壊れる (submodule は親clone
+#   に含まれない) ため、コミット済み実ファイルとして同期する。
+# - CLAUDE.md 変更をトリガにする CI は無いため GITHUB_TOKEN のみで足りる (PAT 不要)。
+# - リポジトリ設定で "Allow GitHub Actions to create and approve pull requests"
+#   を有効化しておくこと。
+#
+# 関連 (Reference):
+# -----------------
+# - Issue #427
+# - 設計書 docs/superpowers/specs/2026-06-13-claude-md-master-sync-design.md
+# ============================================================
+---
+name: Sync CLAUDE.md from master
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-claude-md-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync CLAUDE.md from tvna/claude-md
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Check out this repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Check out master CLAUDE.md
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: tvna/claude-md
+          ref: main
+          sparse-checkout: CLAUDE.md
+          sparse-checkout-cone-mode: false
+          path: .upstream-claude-md
+
+      - name: Copy master CLAUDE.md into place
+        run: |
+          cp .upstream-claude-md/CLAUDE.md CLAUDE.md
+          rm -rf .upstream-claude-md
+
+      - name: Create or update pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: main
+          branch: chore/sync-claude-md
+          delete-branch: true
+          commit-message: "chore: sync CLAUDE.md from tvna/claude-md (#427)"
+          title: "chore: sync CLAUDE.md from tvna/claude-md master"
+          body: |
+            Automated sync of `CLAUDE.md` from the master repository
+            [`tvna/claude-md`](https://github.com/tvna/claude-md) (`main`).
+
+            Source of truth is `tvna/claude-md`. Review required; do not auto-merge.
+
+            Refs #427
+```
+
+- [ ] **Step 2: Lint the workflow**
+
+Run: `actionlint .github/workflows/sync-claude-md.yml`
+Expected: no output, exit code 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/sync-claude-md.yml
+git commit -m "ci: add CLAUDE.md master-sync workflow (#427)"
+```
+
+---
+
+### Task 2: Document the ownership change in CLAUDE.local.md
+
+**Files:**
+- Modify: `CLAUDE.local.md`
+
+- [ ] **Step 1: Append a new section**
+
+Append this section to the end of `CLAUDE.local.md`:
+
+```markdown
+## CLAUDE.md is sourced from the master repo
+
+- `CLAUDE.md` is synced from the master repository
+  [`tvna/claude-md`](https://github.com/tvna/claude-md) by
+  `.github/workflows/sync-claude-md.yml` (weekly + manual), landing via a
+  review PR. The master is the source of truth.
+- Do **not** run `apm compile` to regenerate `CLAUDE.md` locally; the sync
+  workflow is its sole owner. The local `.apm/instructions/` source is vestigial
+  for `CLAUDE.md` (it still drives superpowers skill deployment). Removing it and
+  regenerating `apm.lock.yaml` is deferred to a follow-up in an apm-capable
+  environment. Refs #427.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.local.md
+git commit -m "docs: note CLAUDE.md is upstream-sourced (#427)"
+```
+
+---
+
+### Task 3: Push the branch
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin claude/claude-md-submodule-sync-p0hzmp
+```
+
+---
+
+## Verification
+
+- **Runnable here (fact):** `actionlint` static check of the workflow (Task 1 Step 2).
+- **Runnable after merge:** trigger `workflow_dispatch` on `Sync CLAUDE.md from master`;
+  confirm it opens a PR whose `CLAUDE.md` matches `tvna/claude-md` `main`. Requires the
+  repo setting "Allow GitHub Actions to create and approve pull requests" to be enabled.
+- **Not runnable here (fact):** `apm compile` behavior — apm CLI is not installed. The
+  design avoids depending on it by leaving APM untouched.
+
+## Self-Review notes
+
+- Spec coverage: §2 ownership → Task 2; §3 workflow → Task 1; §4 APM untouched → reflected
+  by not modifying `.apm/`/`apm.lock.yaml` and documented in Task 2; §6 verification → above.
+- No placeholders; all action SHAs pinned to repo-existing versions (checkout v4.2.2,
+  harden-runner v2.13.0) plus create-pull-request v8.1.1 (`5f6978f…`).
+- The repo-setting prerequisite is a config flag (not a secret) and is the only manual handoff.

--- a/docs/superpowers/specs/2026-06-13-claude-md-master-sync-design.md
+++ b/docs/superpowers/specs/2026-06-13-claude-md-master-sync-design.md
@@ -1,0 +1,122 @@
+# CLAUDE.md マスタ追従（定期同期）設計書
+
+**関連:** Issue #427
+**参照:** `tvna/claude-md`（APM で `CLAUDE.md` / `AGENTS.md` をコンパイルして配布するマスタリポジトリ）
+
+---
+
+## 1. 背景と問題
+
+本リポジトリの `CLAUDE.md` は現状、ローカル APM（`.apm/instructions/master.instructions.md`
+＋ `apm.yml`）から `apm compile` で生成されている。一方、エージェント指示の正本は
+別リポジトリ `tvna/claude-md` にあり、README に次のように明記されている（事実）。
+
+> Master repository for personally tuned agent instructions, compiled with
+> microsoft/apm into CLAUDE.md and AGENTS.md **for other projects**.
+> Each project's local agent instructions **reference this master and only add
+> their own delta**.
+
+現状は、このマスタ内容を本リポジトリにローカル二重持ちしており、両者は既に乖離している
+（マスタ Build `71055d42b741` / ローカル Build `195704fa05dc`）。手動同期では追従漏れと
+ドリフトが避けられない。
+
+**目的:** 本リポジトリの `CLAUDE.md` を `tvna/claude-md` の `CLAUDE.md` から
+**定期的に自動追従**させ、ローカル二重持ちを解消する。
+
+### 採用しなかった当初案（submodule + symlink）の却下理由
+
+当初要望は次の方式だった。
+
+```
+git submodule add https://github.com/tvna/claude-md .claude-md-master
+ln -s .claude-md-master/CLAUDE.md CLAUDE.md
+```
+
+これは **Claude Code on the web の fresh clone で破綻する**（根拠の強い推測）。
+
+- 公式ドキュメント: "Cloud sessions start from a fresh clone of your repository.
+  **Anything committed to the repo is available.**" / `CLAUDE.md` → "Part of the clone"。
+- submodule の中身は親リポジトリにコミットされない（親は gitlink＝コミットポインタのみ）。
+  通常の `git clone` は submodule を展開せず、ドキュメントに再帰展開の記載は無い（事実）。
+- 結果、web 環境で `.claude-md-master/` が空となり `CLAUDE.md` が**壊れた symlink** に
+  なり、プロジェクト指示が**サイレントに読み込まれない**。これは `CLAUDE.local.md` を
+  わざわざコミットしている目的（fresh clone でも効かせる）を真っ向から崩す。
+
+したがって **symlink ではなくコミット済み実ファイル**として同期する方式を採る。
+
+## 2. 所有権モデル（アーキテクチャ）
+
+- **同期ワークフローが `CLAUDE.md` の唯一の所有者**となる。`tvna/claude-md` の `main` の
+  `CLAUDE.md` をそのまま**コミット済み実ファイル**として複製する。
+- ローカル APM（`.apm/instructions/master.instructions.md`）は CLAUDE.md 生成元としては
+  **実質引退**する（第4章）。superpowers スキル配備（`.claude/skills/`）の役割は維持。
+- fresh clone でも `CLAUDE.md` は実ファイルとして存在するため、web 環境で確実に読み込まれる。
+
+## 3. 同期ワークフロー `.github/workflows/sync-claude-md.yml`
+
+### トリガ
+- `schedule`: 週次（月曜 06:00 UTC, cron `0 6 * * 1`）。
+- `workflow_dispatch`: 手動実行。
+
+### ジョブ手順
+1. `step-security/harden-runner`（SHA 固定, `egress-policy: audit` ＝既存ワークフロー踏襲）。
+2. `actions/checkout`（SHA 固定）で本リポジトリを取得。
+3. `actions/checkout`（SHA 固定）で `tvna/claude-md` を取得
+   （public, `ref: main`, `sparse-checkout: CLAUDE.md`, 別 `path`）。
+4. マスタの `CLAUDE.md` を本リポジトリの `CLAUDE.md` へコピー。
+5. 差分があれば `peter-evans/create-pull-request`（SHA 固定）で
+   **ブランチ＋コミット＋PR** を作成/更新（既存PRがあれば更新、無ければ新規）。
+
+### 権限・シークレット
+- `GITHUB_TOKEN`（`permissions: contents: write`, `pull-requests: write`）のみ。**PAT 不要**。
+- 理由: `CLAUDE.md` の変更をトリガにする CI は存在しない（`verify-superpowers.yml` の
+  path フィルタは `.claude/skills/**`, `apm.yml`, `apm.lock.yaml` 等）。よって
+  「GITHUB_TOKEN 製 PR が他ワークフローを起動しない」既知制約は本件に影響しない。
+
+### 前提設定（要ハンドオフ・シークレットではない）
+- リポジトリ設定 **Settings → Actions → General → Workflow permissions** で
+  「**Allow GitHub Actions to create and approve pull requests**」を有効化する必要がある。
+  これはフラグであり秘密値ではない。検証は手動 `workflow_dispatch` 実行で PR が
+  作成されることを確認すれば完了。
+
+### レビューゲート
+- 更新は**必ず PR 経由**。自動マージはしない。これにより §2「指示ファイルは
+  code-owner レビューのマージゲートを通す」を満たす。
+
+## 4. APM 整合（検証制約あり）
+
+- 本環境に `apm` CLI が無く `apm.lock.yaml` を再生成できない（事実）。よって本変更では
+  `.apm/instructions/` と `apm.lock.yaml` には**触れない**（生成物の手編集は §3 の
+  declarative 管理に反するため回避）。
+- `apm compile` を **CLAUDE.md 再生成目的では実行しない**運用を `CLAUDE.local.md` に
+  明記する（CLAUDE.md の正本は上流 `tvna/claude-md`、唯一の所有者は同期ワークフロー）。
+- 安全網: 仮に誰かが `apm compile` でローカル差分を出しても、次回の同期 PR が上流へ
+  戻す差分を提示し、レビューで捕捉される。
+- **後続（別 Issue / 別 PR）:** apm 利用可能な環境で `.apm/instructions/master.instructions.md`
+  を撤去し `apm.lock.yaml` を再生成する整理を分離して実施する。
+
+## 5. スコープ外（YAGNI）
+
+- `AGENTS.md` の同期（本リポジトリに `AGENTS.md` は存在しないため対象外）。
+- submodule / symlink 方式（第1章の理由で不採用）。
+- 上流 `ref` の SHA ピン留め（当面は `main` 追従＋ PR レビューを安全制御とする。
+  必要になれば後続で SHA ピンに切替）。
+
+## 6. 検証計画
+
+- 本環境で**可能**:
+  - ワークフロー YAML の静的検証（`actionlint` があれば）。
+  - `workflow_dispatch` による手動実走と、生成 PR の内容目視（マスタの `CLAUDE.md` と一致するか）。
+- 本環境で**不可（事実）**: `apm compile` の挙動確認（apm 未導入）。
+  → APM 整合は「触らない」方針で回避し、本件の検証対象から除外する。
+
+## 7. 影響ファイル
+
+| ファイル | 変更 |
+|---|---|
+| `.github/workflows/sync-claude-md.yml` | 新規（同期ワークフロー） |
+| `CLAUDE.local.md` | CLAUDE.md が上流由来である旨と `apm compile` 非使用方針を追記 |
+| `docs/superpowers/specs/2026-06-13-claude-md-master-sync-design.md` | 本設計書（新規） |
+
+`.apm/instructions/`, `apm.lock.yaml`, `CLAUDE.md` 自体（初回同期PRで更新）は本PRでは
+変更しない。


### PR DESCRIPTION
## Summary

Adds a scheduled GitHub Actions workflow that syncs this repo's `CLAUDE.md` from the
master repository [`tvna/claude-md`](https://github.com/tvna/claude-md), eliminating the
local duplicate that has already drifted from the master.

Closes #427.

## Why not submodule + symlink

The original idea was `git submodule add ... && ln -s .claude-md-master/CLAUDE.md CLAUDE.md`.
That breaks on the Claude-Code-on-the-web fresh clone: submodule contents are not part of
the parent clone, so the symlink would dangle and project instructions would silently fail
to load. This implementation keeps `CLAUDE.md` a committed real file (fresh-clone safe).

## What this does

- `.github/workflows/sync-claude-md.yml`: weekly (`cron 0 6 * * 1`) + `workflow_dispatch`.
  Checks out `tvna/claude-md` (sparse `CLAUDE.md`), copies it over the local `CLAUDE.md`,
  and opens/updates a review PR via `peter-evans/create-pull-request` (pinned by SHA).
- `GITHUB_TOKEN` only, no PAT: no CI is path-filtered on `CLAUDE.md`, so the "token PRs
  don't trigger workflows" limit does not apply here.
- Updates land via PR (review gate). No auto-merge.
- `CLAUDE.local.md`: documents that `CLAUDE.md` is now upstream-owned and `apm compile`
  must not regenerate it locally.

## Required repo setting (manual handoff, not a secret)

Settings -> Actions -> General -> Workflow permissions ->
"Allow GitHub Actions to create and approve pull requests" must be enabled, otherwise the
workflow cannot open the sync PR. After enabling, run the workflow via `workflow_dispatch`
to produce the first sync PR (the local `CLAUDE.md` is currently drifted, so the first run
will produce a diff).

## Out of scope (follow-up)

Removing `.apm/instructions/master.instructions.md` and regenerating `apm.lock.yaml` is
deferred to an apm-capable environment (apm CLI is not installed in the dev environment).
APM is left untouched here; it still drives superpowers skill deployment.

## Verification

- `actionlint .github/workflows/sync-claude-md.yml` -> exit 0 (run locally).
- `apm compile` behavior not verifiable here (apm CLI absent); design avoids depending on it.

Design: `docs/superpowers/specs/2026-06-13-claude-md-master-sync-design.md`
Plan: `docs/superpowers/plans/2026-06-13-claude-md-master-sync.md`

https://claude.ai/code/session_016gDdLNq3DcKkaXaUQ7t76V

---
_Generated by [Claude Code](https://claude.ai/code/session_016gDdLNq3DcKkaXaUQ7t76V)_