### PR TITLE
Add CSV standard template: firewalld rule bulk apply (Rocky Linux)

### DIFF
--- a/assets/examples/firewall-rules.csv
+++ b/assets/examples/firewall-rules.csv
@@ -1,0 +1,5 @@
+zone,action,source,protocol,port,comment
+public,accept,0.0.0.0/0,tcp,443,HTTPS を全ホストに許可
+public,accept,203.0.113.0/24,tcp,22,SSH を保守ネットワークからのみ許可
+internal,accept,10.0.2.0/24,tcp,3306,MySQL をアプリ層サブネットから許可
+dmz,reject,198.51.100.0/24,tcp,8080,旧API ポートを拒否(reject で明示応答)

--- a/assets/examples/firewall-rules.j2
+++ b/assets/examples/firewall-rules.j2
@@ -1,0 +1,38 @@
+# firewalld ルール一括投入手順 — Rocky Linux
+
+CSV で定義した {{ csv_rows | length }} 件のアクセス制御ルールを、firewalld の
+rich rule として一括投入します。Rocky Linux 9 標準（firewalld + nftables
+バックエンド）を前提に、root 権限で上から順に実行してください。
+
+## 1. 投入するルール一覧
+
+| zone | action | source | protocol | port | 用途 |
+|------|--------|--------|----------|------|------|
+{% for r in csv_rows %}| {{ r["zone"] }} | {{ r["action"] }} | {{ r["source"] }} | {{ r["protocol"] }} | {{ r["port"] }} | {{ r["comment"] }} |
+{% endfor %}
+
+## 2. firewalld の稼働を確認する
+
+```bash
+systemctl enable --now firewalld
+firewall-cmd --state
+```
+
+## 3. ルールを永続設定として投入する
+
+各 CSV 行を 1 本の rich rule に対応させます。--permanent のため、この時点では
+runtime にはまだ反映されません。
+
+```bash
+{% for r in csv_rows %}firewall-cmd --zone={{ r["zone"] }} --permanent --add-rich-rule='rule family="ipv4" source address="{{ r["source"] }}" port port="{{ r["port"] }}" protocol="{{ r["protocol"] }}" {{ r["action"] }}'
+{% endfor %}```
+
+## 4. 設定を反映して確認する
+
+```bash
+firewall-cmd --reload
+firewall-cmd --list-all-zones
+```
+
+> reject と drop の違い: reject は拒否応答（ICMP）を返し、drop は無応答で破棄します。
+> 意図に応じて使い分けてください。

--- a/web/src/lib/templates.ts
+++ b/web/src/lib/templates.ts
@@ -1,7 +1,7 @@
 import type { Template, TemplateCategory, TemplateOutput } from "./types";
 import type { Format } from "./format";
 
-const raw = import.meta.glob("../../../assets/examples/*.{toml,yaml,j2}", {
+const raw = import.meta.glob("../../../assets/examples/*.{toml,yaml,csv,j2}", {
   query: "?raw",
   eager: true,
   import: "default",
@@ -31,6 +31,7 @@ const META: Meta[] = [
   { id: "dns-zone", name: "DNS ゾーンファイル初期化", desc: "$ORIGIN / $TTL / SOA / NS / MX / A / 各種 TXT を含むゾーンを、登録・反映手順書（Markdown）として生成。", category: "dns", format: "toml", output: "markdown", updated: "2026-06-30", live: true },
   { id: "incident-campus", name: "キャンパスネットワーク障害対応", desc: "症状・影響範囲・切り分けステップ・エスカレーションから Markdown 手順書を生成。", category: "runbook", format: "yaml", output: "markdown", updated: "2026-06-18", live: true },
   { id: "incident-proxy", name: "プロキシ環境のWebサービス接続不能", desc: "プロキシ設定・確認コマンド・判断分岐から Markdown 切り分け手順書を生成。", category: "runbook", format: "yaml", output: "markdown", updated: "2026-06-15", live: true },
+  { id: "firewall-rules", name: "firewalld ルール一括投入", desc: "CSV の 1 行 1 ルールから、Rocky Linux 標準の firewalld rich rule 投入手順書（Markdown）を生成。", category: "network", format: "csv", output: "markdown", updated: "2026-06-30", live: true },
 ];
 
 export const CGTemplates: Template[] = META.map((m) => ({


### PR DESCRIPTION
## Summary

Adds the first CSV-based config-definition example to the standard template set.
Until now the only CSV sample was the DNS `dig` query template, and the web
frontend registered no CSV example at all -- its example-loader glob
(`*.{toml,yaml,j2}`) did not even include `.csv`.

This adds an infrastructure-engineering pattern: a "1 row = 1 ACL rule" CSV that
generates a Markdown runbook of **firewalld rich-rule** commands, targeting the
Rocky Linux standard (firewalld + nftables backend).

Closes #454

## Changes

- `assets/examples/firewall-rules.csv` (new): one row per rule
  (`zone,action,source,protocol,port,comment`).
- `assets/examples/firewall-rules.j2` (new): renders a Markdown runbook -- a rule
  summary table plus the per-row `firewall-cmd --add-rich-rule ... --permanent`
  commands and a reload/verify step.
- `web/src/lib/templates.ts`: include `csv` in the example-loader glob and
  register one `META` entry (`firewall-rules`, category `network`, format `csv`,
  output `markdown`).

## Design notes

- Web defaults are `enableFillNan: true` / `fillNanWith: "#"` with
  `isStrictUndefined: true`, so empty CSV cells become `#` rather than being
  falsy. The template therefore uses **all columns as required** with no
  conditional-on-empty logic; "any source" is expressed as `0.0.0.0/0`.
- Row access uses subscript notation (`r["zone"]`) to match the existing CSV
  example and avoid dict-method name collisions. Only the standard `length`
  filter is used.
- `category` is `network` (host firewall could also be `server`).

## Verification

- Rendered `firewall-rules.csv` + `firewall-rules.j2` through the Python `AppCore`
  with web defaults (`fillNanWith="#"`, strict undefined): no config/template
  error, all 4 rules expand into well-formed rich rules.
- `tsc -b`: passes.
- `vitest run`: 34 tests pass (templates.ts glob + META resolve the new example).
- `pytest tests/test_app_integration.py`: 29 pass (sample count is derived from
  the directory, so it auto-adjusts; no test change needed).

## Scope

- Streamlit `app.py` auto-discovers examples by directory scan, so no
  registration is needed there.
- The web preview runs the same Python parser via Pyodide, so `csv_rows` is
  consistent across both surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1DoNa9uS961j3knaxhzpN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1DoNa9uS961j3knaxhzpN)_