### PR TITLE
ci: sign sync-claude-md commits to fix unmergeable PR (#464)

### DIFF
--- a/.github/workflows/sync-claude-md.yml
+++ b/.github/workflows/sync-claude-md.yml
@@ -15,10 +15,14 @@
 # - CLAUDE.md 変更をトリガにする CI は無いため GITHUB_TOKEN のみで足りる (PAT 不要)。
 # - リポジトリ設定で "Allow GitHub Actions to create and approve pull requests"
 #   を有効化しておくこと。
+# - create-pull-request の sign-commits: true により、ローカル git commit ではなく
+#   GitHub API 経由でコミットを作成し、GITHUB_TOKEN のままで Verified 署名済みコミット
+#   とする (新規 GitHub App / secret は不要)。未設定だと署名必須ブランチ保護で
+#   PR が `mergeable_state: blocked` のままマージ不能になる (PR #464 で発生)。
 #
 # 関連 (Reference):
 # -----------------
-# - Issue #427
+# - Issue #427, #467
 # - 設計書 docs/superpowers/specs/2026-06-13-claude-md-master-sync-design.md
 # ============================================================
 ---
@@ -71,6 +75,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          sign-commits: true
           base: main
           branch: chore/sync-claude-md
           delete-branch: true
@@ -82,4 +87,4 @@ jobs:
 
             Source of truth is `tvna/claude-md`. Review required; do not auto-merge.
 
-            Refs #427
+            Refs #427, #467


### PR DESCRIPTION
## Summary

- PR #464 (`chore: sync CLAUDE.md from tvna/claude-md master`) is unmergeable: all CI
  checks pass, but `mergeable_state` stays `blocked` because its commits aren't signed,
  and the branch requires signed commits.
- `peter-evans/create-pull-request` (used by `.github/workflows/sync-claude-md.yml`)
  defaults to a local `git commit`, which GitHub never marks "Verified" even with
  `GITHUB_TOKEN`.
- Enable the action's built-in `sign-commits: true` input so the commit is created via
  the GitHub API instead, which GitHub signs/verifies as `github-actions[bot]` — no new
  GitHub App or secret needed. This mirrors the server-side commit approach used by
  `tvna/claude-md`'s own post-merge automation
  (https://github.com/tvna/claude-md/actions/runs/28466165419/workflow?pr=2184), which
  uses `createCommitOnBranch` for the same reason.

## Test plan

- [ ] Re-run `sync-claude-md.yml` via `workflow_dispatch` and confirm the new commit on
      `chore/sync-claude-md` shows "Verified" on GitHub
- [ ] Confirm the resulting PR's `mergeable_state` is no longer `blocked`
- [ ] Close/replace PR #464 once a signed sync PR supersedes it

Refs #427, #467

https://claude.ai/code/session_01NWnYWcheLZufDtknymLRnm


---
_Generated by [Claude Code](https://claude.ai/code/session_01NWnYWcheLZufDtknymLRnm)_