### PR TITLE
[codex] fix web file upload controls

### DIFF
--- a/tests/workflow/test_release_management.py
+++ b/tests/workflow/test_release_management.py
@@ -9,7 +9,7 @@ import yaml
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def load_workflow() -> dict[str, Any]:
+def load_workflow() -> dict[Any, Any]:
     with (ROOT / ".github" / "workflows" / "release.yml").open(encoding="utf-8") as workflow_file:
         return yaml.safe_load(workflow_file)
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 // jsdom has no real Worker; mock the worker module so mount doesn't crash.
 vi.mock("./worker/generate.worker?worker", () => ({
@@ -23,5 +23,17 @@ describe("App shell", () => {
     location.hash = "#/new";
     render(<App />);
     expect(screen.getByText("Command ghostwriter")).toBeTruthy();
+  });
+  it("loads a selected config file from the empty state into the editor", async () => {
+    const { container } = render(<App />);
+    const inputs = container.querySelectorAll('input[type="file"]');
+    expect(inputs.length).toBeGreaterThanOrEqual(2);
+
+    const file = new File(["hostname = \"router-001\""], "router.toml", { type: "application/toml" });
+    fireEvent.change(inputs[0], { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("hostname = \"router-001\"")).toBeTruthy();
+    });
   });
 });

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import Encoding from "encoding-japanese";
 
 // jsdom has no real Worker; mock the worker module so mount doesn't crash.
 vi.mock("./worker/generate.worker?worker", () => ({
@@ -37,6 +38,19 @@ describe("App shell", () => {
       expect(screen.getByDisplayValue("hostname = \"router-001\"")).toBeTruthy();
     });
   });
+  it("decodes uploaded Shift_JIS config files before opening the editor", async () => {
+    const { container } = render(<App />);
+    const inputs = container.querySelectorAll('input[type="file"]');
+    const codes = Encoding.stringToCode("hostname = \"東京\"");
+    const sjis = new Uint8Array(Encoding.convert(codes, { to: "SJIS", from: "UNICODE" }));
+    const file = new File([sjis], "router.toml", { type: "application/toml" });
+
+    fireEvent.change(inputs[0], { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("hostname = \"東京\"")).toBeTruthy();
+    });
+  });
   it("loads a selected Jinja template file from the empty state into the editor", async () => {
     const { container } = render(<App />);
     const inputs = container.querySelectorAll('input[type="file"]');
@@ -55,7 +69,7 @@ describe("App shell", () => {
     const { container } = render(<App />);
     const inputs = container.querySelectorAll('input[type="file"]');
     const file = new File([""], "broken.toml", { type: "application/toml" });
-    Object.defineProperty(file, "text", { value: () => Promise.reject(new Error("read failed")) });
+    Object.defineProperty(file, "arrayBuffer", { value: () => Promise.reject(new Error("read failed")) });
 
     fireEvent.change(inputs[0], { target: { files: [file] } });
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -28,6 +28,7 @@ describe("App shell", () => {
     const { container } = render(<App />);
     const inputs = container.querySelectorAll('input[type="file"]');
     expect(inputs.length).toBeGreaterThanOrEqual(2);
+    expect(inputs[0].getAttribute("accept")).toBe(".toml,.yaml,.yml,.csv");
 
     const file = new File(["hostname = \"router-001\""], "router.toml", { type: "application/toml" });
     fireEvent.change(inputs[0], { target: { files: [file] } });
@@ -35,5 +36,29 @@ describe("App shell", () => {
     await waitFor(() => {
       expect(screen.getByDisplayValue("hostname = \"router-001\"")).toBeTruthy();
     });
+  });
+  it("loads a selected Jinja template file from the empty state into the editor", async () => {
+    const { container } = render(<App />);
+    const inputs = container.querySelectorAll('input[type="file"]');
+    expect(inputs.length).toBeGreaterThanOrEqual(2);
+    expect(inputs[1].getAttribute("accept")).toBe(".j2,.jinja2");
+
+    const file = new File(["interface {{ name }}"], "interface.j2", { type: "text/plain" });
+    fireEvent.change(inputs[1], { target: { files: [file] } });
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByRole("button", { name: "テンプレート" }));
+      expect(screen.getByDisplayValue("interface {{ name }}")).toBeTruthy();
+    });
+  });
+  it("shows an inline error when an upload cannot be read", async () => {
+    const { container } = render(<App />);
+    const inputs = container.querySelectorAll('input[type="file"]');
+    const file = new File([""], "broken.toml", { type: "application/toml" });
+    Object.defineProperty(file, "text", { value: () => Promise.reject(new Error("read failed")) });
+
+    fireEvent.change(inputs[0], { target: { files: [file] } });
+
+    expect((await screen.findByRole("alert")).textContent).toBe("broken.toml を読み込めませんでした。別のファイルを選択してください。");
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Analytics } from "@vercel/analytics/react";
+import Encoding from "encoding-japanese";
 import { EmptyState } from "./components/EmptyState";
 import { Library } from "./components/Library";
 import { Editor } from "./components/Editor";
@@ -65,12 +66,23 @@ function uploadedTemplate(file: File, content: string, kind: "config" | "templat
 }
 
 function readFileText(file: File): Promise<string> {
-  if ("text" in file && typeof file.text === "function") return file.text();
+  const decodeBytes = (buffer: ArrayBuffer): string => {
+    const bytes = new Uint8Array(buffer);
+    const detected = Encoding.detect(bytes, ["UTF8", "SJIS", "EUCJP", "JIS", "UTF16"]) || "UTF8";
+    const unicode = Encoding.convert(bytes, { to: "UNICODE", from: detected });
+    return Encoding.codeToString(unicode);
+  };
+  if ("arrayBuffer" in file && typeof file.arrayBuffer === "function") {
+    return file.arrayBuffer().then(decodeBytes);
+  }
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
-    reader.onload = () => resolve(String(reader.result || ""));
+    reader.onload = () => {
+      if (reader.result instanceof ArrayBuffer) resolve(decodeBytes(reader.result));
+      else resolve(String(reader.result || ""));
+    };
     reader.onerror = () => reject(reader.error || new Error(`Failed to read ${file.name}`));
-    reader.readAsText(file);
+    reader.readAsArrayBuffer(file);
   });
 }
 
@@ -126,6 +138,7 @@ export function App() {
         onLibrary={() => go("#/library")}
         onConfigFile={(file) => void openUploadedFile(file, "config")}
         onTemplateFile={(file) => void openUploadedFile(file, "template")}
+        onUploadError={setUploadError}
         uploadError={uploadError}
       />
     );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,8 @@ import { Library } from "./components/Library";
 import { Editor } from "./components/Editor";
 import { CGTemplates } from "./lib/templates";
 import type { Template } from "./lib/types";
+import { CG } from "./lib/data";
+import type { Format } from "./lib/format";
 import type { DownloadOptions } from "./components/SettingsModal";
 import { DEFAULT_SETTINGS, type GenerateSettings } from "./worker/types";
 
@@ -39,10 +41,44 @@ function analyticsLocation(): { route: string; path: string } {
 
 const DEFAULT_DOWNLOAD: DownloadOptions = { enc: "UTF-8", fname: "command", ts: true, ext: "txt" };
 
+function formatFromFileName(name: string): Format {
+  const ext = name.split(".").pop()?.toLowerCase();
+  if (ext === "yaml" || ext === "yml") return "yaml";
+  if (ext === "csv") return "csv";
+  return "toml";
+}
+
+function uploadedTemplate(file: File, content: string, kind: "config" | "template"): Template {
+  const isConfig = kind === "config";
+  return {
+    id: `uploaded-${kind}`,
+    name: file.name,
+    desc: "アップロードしたファイルから作成した一時ドキュメント。",
+    category: "network",
+    format: isConfig ? formatFromFileName(file.name) : "toml",
+    output: "markdown",
+    updated: new Date().toISOString().slice(0, 10),
+    live: true,
+    data: isConfig ? content : CG.configToml,
+    template: isConfig ? CG.templateJ2 : content,
+  };
+}
+
+function readFileText(file: File): Promise<string> {
+  if ("text" in file && typeof file.text === "function") return file.text();
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result || ""));
+    reader.onerror = () => reject(reader.error || new Error(`Failed to read ${file.name}`));
+    reader.readAsText(file);
+  });
+}
+
 export function App() {
   const [route, setRoute] = React.useState<Route>(routeFromHash);
   const [settings, setSettings] = React.useState<GenerateSettings>(DEFAULT_SETTINGS);
   const [download, setDownload] = React.useState<DownloadOptions>(DEFAULT_DOWNLOAD);
+  const [draftTemplate, setDraftTemplate] = React.useState<Template | null>(null);
 
   React.useEffect(() => {
     const on = () => setRoute(routeFromHash());
@@ -52,13 +88,23 @@ export function App() {
 
   const go = (hash: string) => { location.hash = hash; };
   const back = () => history.back();
-  const openEditor = (tpl: Template | null) => go(tpl ? "#/t/" + encodeURIComponent(tpl.id) : "#/new");
+  const openEditor = (tpl: Template | null) => {
+    setDraftTemplate(null);
+    go(tpl ? "#/t/" + encodeURIComponent(tpl.id) : "#/new");
+  };
+  const openUploadedFile = async (file: File, kind: "config" | "template") => {
+    const content = await readFileText(file);
+    setDraftTemplate(uploadedTemplate(file, content, kind));
+    go("#/new");
+  };
+
+  const editorInitial = route.initial || draftTemplate;
 
   const content =
     route.view === "editor" ? (
       <Editor
-        key={route.initial ? route.initial.id : "blank"}
-        initial={route.initial}
+        key={editorInitial ? `${editorInitial.id}:${editorInitial.name}` : "blank"}
+        initial={editorInitial}
         onBack={back}
         settings={settings}
         onSettings={setSettings}
@@ -68,7 +114,12 @@ export function App() {
     ) : route.view === "library" ? (
       <Library onOpen={openEditor} onClose={back} />
     ) : (
-      <EmptyState onStart={() => openEditor(null)} onLibrary={() => go("#/library")} />
+      <EmptyState
+        onStart={() => openEditor(null)}
+        onLibrary={() => go("#/library")}
+        onConfigFile={(file) => void openUploadedFile(file, "config")}
+        onTemplateFile={(file) => void openUploadedFile(file, "template")}
+      />
     );
 
   const analytics = analyticsLocation();

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -79,6 +79,7 @@ export function App() {
   const [settings, setSettings] = React.useState<GenerateSettings>(DEFAULT_SETTINGS);
   const [download, setDownload] = React.useState<DownloadOptions>(DEFAULT_DOWNLOAD);
   const [draftTemplate, setDraftTemplate] = React.useState<Template | null>(null);
+  const [uploadError, setUploadError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
     const on = () => setRoute(routeFromHash());
@@ -90,12 +91,18 @@ export function App() {
   const back = () => history.back();
   const openEditor = (tpl: Template | null) => {
     setDraftTemplate(null);
+    setUploadError(null);
     go(tpl ? "#/t/" + encodeURIComponent(tpl.id) : "#/new");
   };
   const openUploadedFile = async (file: File, kind: "config" | "template") => {
-    const content = await readFileText(file);
-    setDraftTemplate(uploadedTemplate(file, content, kind));
-    go("#/new");
+    try {
+      const content = await readFileText(file);
+      setUploadError(null);
+      setDraftTemplate(uploadedTemplate(file, content, kind));
+      go("#/new");
+    } catch {
+      setUploadError(`${file.name} を読み込めませんでした。別のファイルを選択してください。`);
+    }
   };
 
   const editorInitial = route.initial || draftTemplate;
@@ -119,6 +126,7 @@ export function App() {
         onLibrary={() => go("#/library")}
         onConfigFile={(file) => void openUploadedFile(file, "config")}
         onTemplateFile={(file) => void openUploadedFile(file, "template")}
+        uploadError={uploadError}
       />
     );
 

--- a/web/src/components/EmptyState.tsx
+++ b/web/src/components/EmptyState.tsx
@@ -99,9 +99,10 @@ export interface EmptyStateProps {
   onLibrary?: () => void;
   onConfigFile?: (file: File) => void;
   onTemplateFile?: (file: File) => void;
+  uploadError?: string | null;
 }
 
-export function EmptyState({ onStart, onLibrary, onConfigFile, onTemplateFile }: EmptyStateProps) {
+export function EmptyState({ onStart, onLibrary, onConfigFile, onTemplateFile, uploadError }: EmptyStateProps) {
   const [howto, setHowto] = useState(false);
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: 'var(--cg-bg)', fontFamily: 'var(--font-sans)', color: 'var(--cg-text)', position: 'relative', overflow: 'hidden' }}>
@@ -220,6 +221,12 @@ export function EmptyState({ onStart, onLibrary, onConfigFile, onTemplateFile }:
                 onFile={onTemplateFile}
               />
             </div>
+
+            {uploadError && (
+              <div role="alert" style={{ marginTop: 12, padding: '10px 12px', border: '1px solid var(--cg-error-border)', borderRadius: 'var(--radius-md)', background: 'var(--cg-error-bg)', color: 'var(--cg-red-tint)', fontSize: 'var(--text-sm)' }}>
+                {uploadError}
+              </div>
+            )}
 
             {/* library link */}
             <div style={{ marginTop: 18, textAlign: 'center' }}>

--- a/web/src/components/EmptyState.tsx
+++ b/web/src/components/EmptyState.tsx
@@ -97,9 +97,11 @@ function Op({ children, accent }: { children: ReactNode; accent?: boolean }) {
 export interface EmptyStateProps {
   onStart: (mode?: string) => void;
   onLibrary?: () => void;
+  onConfigFile?: (file: File) => void;
+  onTemplateFile?: (file: File) => void;
 }
 
-export function EmptyState({ onStart, onLibrary }: EmptyStateProps) {
+export function EmptyState({ onStart, onLibrary, onConfigFile, onTemplateFile }: EmptyStateProps) {
   const [howto, setHowto] = useState(false);
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: 'var(--cg-bg)', fontFamily: 'var(--font-sans)', color: 'var(--cg-text)', position: 'relative', overflow: 'hidden' }}>
@@ -205,8 +207,18 @@ export function EmptyState({ onStart, onLibrary }: EmptyStateProps) {
 
             {/* uploads */}
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
-              <FileUploader label="① 設定定義ファイル" accept="TOML, YAML, CSV" onBrowse={() => onStart('upload')} />
-              <FileUploader label="② Jinjaテンプレート" accept="J2, JINJA2" onBrowse={() => onStart('upload')} />
+              <FileUploader
+                label="① 設定定義ファイル"
+                accept=".toml,.yaml,.yml,.csv"
+                acceptLabel="TOML, YAML, CSV"
+                onFile={onConfigFile}
+              />
+              <FileUploader
+                label="② Jinjaテンプレート"
+                accept=".j2,.jinja2"
+                acceptLabel="J2, JINJA2"
+                onFile={onTemplateFile}
+              />
             </div>
 
             {/* library link */}

--- a/web/src/components/EmptyState.tsx
+++ b/web/src/components/EmptyState.tsx
@@ -99,10 +99,11 @@ export interface EmptyStateProps {
   onLibrary?: () => void;
   onConfigFile?: (file: File) => void;
   onTemplateFile?: (file: File) => void;
+  onUploadError?: (message: string) => void;
   uploadError?: string | null;
 }
 
-export function EmptyState({ onStart, onLibrary, onConfigFile, onTemplateFile, uploadError }: EmptyStateProps) {
+export function EmptyState({ onStart, onLibrary, onConfigFile, onTemplateFile, onUploadError, uploadError }: EmptyStateProps) {
   const [howto, setHowto] = useState(false);
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: 'var(--cg-bg)', fontFamily: 'var(--font-sans)', color: 'var(--cg-text)', position: 'relative', overflow: 'hidden' }}>
@@ -213,12 +214,14 @@ export function EmptyState({ onStart, onLibrary, onConfigFile, onTemplateFile, u
                 accept=".toml,.yaml,.yml,.csv"
                 acceptLabel="TOML, YAML, CSV"
                 onFile={onConfigFile}
+                onError={onUploadError}
               />
               <FileUploader
                 label="② Jinjaテンプレート"
                 accept=".j2,.jinja2"
                 acceptLabel="J2, JINJA2"
                 onFile={onTemplateFile}
+                onError={onUploadError}
               />
             </div>
 

--- a/web/src/ds/FileUploader.tsx
+++ b/web/src/ds/FileUploader.tsx
@@ -10,10 +10,12 @@ export interface FileUploaderProps {
   accept?: string;
   acceptLabel?: string;
   maxSize?: string;
+  maxBytes?: number;
   fileName?: string | null;
   fileSize?: string;
   onBrowse?: () => void;
   onFile?: (file: File) => void;
+  onError?: (message: string) => void;
   style?: React.CSSProperties;
 }
 
@@ -22,10 +24,12 @@ export function FileUploader({
   accept = '',
   acceptLabel,
   maxSize = '30MB',
+  maxBytes = 30 * 1024 * 1024,
   fileName = null,
   fileSize = '',
   onBrowse,
   onFile,
+  onError,
   style,
 }: FileUploaderProps) {
   const [hover, setHover] = React.useState(false);
@@ -36,7 +40,11 @@ export function FileUploader({
   };
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.currentTarget.files?.[0];
-    if (file) onFile?.(file);
+    if (file && file.size > maxBytes) {
+      onError?.(`${file.name} は${maxSize}以下のファイルを選択してください。`);
+    } else if (file) {
+      onFile?.(file);
+    }
     event.currentTarget.value = '';
   };
 

--- a/web/src/ds/FileUploader.tsx
+++ b/web/src/ds/FileUploader.tsx
@@ -8,23 +8,38 @@ import React from 'react';
 export interface FileUploaderProps {
   label?: React.ReactNode;
   accept?: string;
+  acceptLabel?: string;
   maxSize?: string;
   fileName?: string | null;
   fileSize?: string;
   onBrowse?: () => void;
+  onFile?: (file: File) => void;
   style?: React.CSSProperties;
 }
 
 export function FileUploader({
   label,
   accept = '',
+  acceptLabel,
   maxSize = '30MB',
   fileName = null,
   fileSize = '',
   onBrowse,
+  onFile,
   style,
 }: FileUploaderProps) {
   const [hover, setHover] = React.useState(false);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const handleBrowse = () => {
+    inputRef.current?.click();
+    onBrowse?.();
+  };
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.currentTarget.files?.[0];
+    if (file) onFile?.(file);
+    event.currentTarget.value = '';
+  };
+
   return (
     <div style={{ fontFamily: 'var(--font-sans)', ...style }}>
       {label && (
@@ -54,12 +69,11 @@ export function FileUploader({
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ fontSize: 'var(--text-sm)', color: 'var(--text-body)' }}>Drag and drop file here</div>
           <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-secondary)', marginTop: 2 }}>
-            Limit {maxSize} per file{accept ? ` · ${accept}` : ''}
+            Limit {maxSize} per file{(acceptLabel || accept) ? ` · ${acceptLabel || accept}` : ''}
           </div>
         </div>
         <button
           type="button"
-          onClick={onBrowse}
           style={{
             fontFamily: 'var(--font-sans)',
             fontSize: 'var(--text-sm)',
@@ -72,9 +86,19 @@ export function FileUploader({
             cursor: 'pointer',
             whiteSpace: 'nowrap',
           }}
+          onClick={handleBrowse}
         >
           Browse files
         </button>
+        <input
+          ref={inputRef}
+          type="file"
+          accept={accept}
+          onChange={handleFileChange}
+          style={{ display: 'none' }}
+          aria-hidden="true"
+          tabIndex={-1}
+        />
       </div>
 
       {fileName && (

--- a/web/src/ds/ds.smoke.test.tsx
+++ b/web/src/ds/ds.smoke.test.tsx
@@ -61,6 +61,19 @@ describe("DS primitives smoke", () => {
     expect(onFile).toHaveBeenCalledWith(file);
   });
 
+  it("FileUploader rejects files over its byte limit before reporting them", () => {
+    const onFile = vi.fn();
+    const onError = vi.fn();
+    const { container } = render(<FileUploader label="アップロード" maxBytes={4} onFile={onFile} onError={onError} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["12345"], "large.toml", { type: "application/toml" });
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(onFile).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith("large.toml は30MB以下のファイルを選択してください。");
+  });
+
   it("Divider renders an hr element", () => {
     const { container } = render(<Divider variant="rainbow" />);
     expect(container.querySelector("hr")).toBeTruthy();

--- a/web/src/ds/ds.smoke.test.tsx
+++ b/web/src/ds/ds.smoke.test.tsx
@@ -47,6 +47,20 @@ describe("DS primitives smoke", () => {
     expect(screen.getByText("アップロード")).toBeTruthy();
   });
 
+  it("FileUploader exposes a native file input and reports selected files", () => {
+    const onFile = vi.fn();
+    const { container } = render(<FileUploader label="アップロード" accept=".toml,.yaml,.csv" onFile={onFile} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement | null;
+    expect(input).toBeTruthy();
+    expect(input?.getAttribute("accept")).toBe(".toml,.yaml,.csv");
+
+    const file = new File(["hostname = \"router-001\""], "config.toml", { type: "application/toml" });
+    fireEvent.change(input as HTMLInputElement, { target: { files: [file] } });
+
+    expect(onFile).toHaveBeenCalledTimes(1);
+    expect(onFile).toHaveBeenCalledWith(file);
+  });
+
   it("Divider renders an hr element", () => {
     const { container } = render(<Divider variant="rainbow" />);
     expect(container.querySelector("hr")).toBeTruthy();


### PR DESCRIPTION
## Summary
- Add a native file input behind the first-screen Browse files controls.
- Wire selected config and Jinja template files into the editor as temporary uploaded documents.
- Add tests for the file input contract and first-screen config upload flow.

## Root cause
The current Vercel UI rendered Browse files buttons without an associated native file input, so clicking the control could not open the OS file picker.

## Validation
- npm test -- src/ds/ds.smoke.test.tsx
- npm test -- src/App.test.tsx
- npm run build
- npm test
- Browser DOM check on http://127.0.0.1:5173/ confirmed two file inputs with .toml/.yaml/.yml/.csv and .j2/.jinja2 accept filters.