### PR TITLE
Fix two-file upload gating in web UI

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -119,4 +119,24 @@ describe("App shell", () => {
 
     expect((await screen.findByRole("alert")).textContent).toBe("broken.toml を読み込めませんでした。別のファイルを選択してください。");
   });
+  it("preserves one upload slot's error when the other slot succeeds later", async () => {
+    const { container } = render(<App />);
+    const inputs = container.querySelectorAll('input[type="file"]');
+    let rejectConfig: ((error: Error) => void) | undefined;
+    const config = new File([""], "broken.toml", { type: "application/toml" });
+    Object.defineProperty(config, "arrayBuffer", {
+      value: () => new Promise<ArrayBuffer>((_, reject) => { rejectConfig = reject; }),
+    });
+    const template = new File(["hostname {{ hostname }}"], "command.j2", { type: "text/plain" });
+
+    fireEvent.change(inputs[0], { target: { files: [config] } });
+    fireEvent.change(inputs[1], { target: { files: [template] } });
+    rejectConfig?.(new Error("read failed"));
+
+    expect((await screen.findByRole("alert")).textContent).toBe("broken.toml を読み込めませんでした。別のファイルを選択してください。");
+    await waitFor(() => {
+      expect(screen.getByText("command.j2")).toBeTruthy();
+    });
+    expect(screen.getByRole("alert").textContent).toBe("broken.toml を読み込めませんでした。別のファイルを選択してください。");
+  });
 });

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -14,6 +14,10 @@ vi.mock("./worker/generate.worker?worker", () => ({
 
 import { App } from "./App";
 
+function textBuffer(text: string): ArrayBuffer {
+  return Uint8Array.from(Array.from(text, (char) => char.charCodeAt(0))).buffer;
+}
+
 describe("App shell", () => {
   beforeEach(() => { location.hash = ""; });
   it("renders the empty state at #/", () => {
@@ -25,18 +29,29 @@ describe("App shell", () => {
     render(<App />);
     expect(screen.getByText("Command ghostwriter")).toBeTruthy();
   });
-  it("loads a selected config file from the empty state into the editor", async () => {
+  it("waits for both uploaded files before opening the editor", async () => {
     const { container } = render(<App />);
     const inputs = container.querySelectorAll('input[type="file"]');
     expect(inputs.length).toBeGreaterThanOrEqual(2);
     expect(inputs[0].getAttribute("accept")).toBe(".toml,.yaml,.yml,.csv");
+    expect(inputs[1].getAttribute("accept")).toBe(".j2,.jinja2");
 
-    const file = new File(["hostname = \"router-001\""], "router.toml", { type: "application/toml" });
-    fireEvent.change(inputs[0], { target: { files: [file] } });
+    const config = new File(["hostname = \"router-001\""], "router.toml", { type: "application/toml" });
+    fireEvent.change(inputs[0], { target: { files: [config] } });
+
+    await waitFor(() => {
+      expect(screen.getByText("router.toml")).toBeTruthy();
+    });
+    expect(screen.queryByDisplayValue("hostname = \"router-001\"")).toBeNull();
+
+    const template = new File(["hostname {{ hostname }}"], "command.j2", { type: "text/plain" });
+    fireEvent.change(inputs[1], { target: { files: [template] } });
 
     await waitFor(() => {
       expect(screen.getByDisplayValue("hostname = \"router-001\"")).toBeTruthy();
     });
+    fireEvent.click(screen.getByRole("button", { name: "テンプレート" }));
+    expect(screen.getByDisplayValue("hostname {{ hostname }}")).toBeTruthy();
   });
   it("decodes uploaded Shift_JIS config files before opening the editor", async () => {
     const { container } = render(<App />);
@@ -45,13 +60,16 @@ describe("App shell", () => {
     const sjis = new Uint8Array(Encoding.convert(codes, { to: "SJIS", from: "UNICODE" }));
     const file = new File([sjis], "router.toml", { type: "application/toml" });
 
+    const template = new File(["hostname {{ hostname }}"], "command.j2", { type: "text/plain" });
+
     fireEvent.change(inputs[0], { target: { files: [file] } });
+    fireEvent.change(inputs[1], { target: { files: [template] } });
 
     await waitFor(() => {
       expect(screen.getByDisplayValue("hostname = \"東京\"")).toBeTruthy();
     });
   });
-  it("loads a selected Jinja template file from the empty state into the editor", async () => {
+  it("waits on the empty state when only a Jinja template has been uploaded", async () => {
     const { container } = render(<App />);
     const inputs = container.querySelectorAll('input[type="file"]');
     expect(inputs.length).toBeGreaterThanOrEqual(2);
@@ -61,9 +79,35 @@ describe("App shell", () => {
     fireEvent.change(inputs[1], { target: { files: [file] } });
 
     await waitFor(() => {
-      fireEvent.click(screen.getByRole("button", { name: "テンプレート" }));
-      expect(screen.getByDisplayValue("interface {{ name }}")).toBeTruthy();
+      expect(screen.getByText("interface.j2")).toBeTruthy();
     });
+    expect(screen.queryByRole("button", { name: "テンプレート" })).toBeNull();
+  });
+  it("ignores stale reads when a newer file is selected for the same upload slot", async () => {
+    const { container } = render(<App />);
+    const inputs = container.querySelectorAll('input[type="file"]');
+    let resolveOldConfig: ((buffer: ArrayBuffer) => void) | undefined;
+    const oldConfig = new File([""], "old.toml", { type: "application/toml" });
+    Object.defineProperty(oldConfig, "arrayBuffer", {
+      value: () => new Promise<ArrayBuffer>((resolve) => { resolveOldConfig = resolve; }),
+    });
+    const newConfig = new File(["hostname = \"new\""], "new.toml", { type: "application/toml" });
+
+    fireEvent.change(inputs[0], { target: { files: [oldConfig] } });
+    fireEvent.change(inputs[0], { target: { files: [newConfig] } });
+
+    await waitFor(() => {
+      expect(screen.getByText("new.toml")).toBeTruthy();
+    });
+
+    resolveOldConfig?.(textBuffer("hostname = \"old\""));
+    const template = new File(["hostname {{ hostname }}"], "command.j2", { type: "text/plain" });
+    fireEvent.change(inputs[1], { target: { files: [template] } });
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("hostname = \"new\"")).toBeTruthy();
+    });
+    expect(screen.queryByDisplayValue("hostname = \"old\"")).toBeNull();
   });
   it("shows an inline error when an upload cannot be read", async () => {
     const { container } = render(<App />);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,12 +6,12 @@ import { Library } from "./components/Library";
 import { Editor } from "./components/Editor";
 import { CGTemplates } from "./lib/templates";
 import type { Template } from "./lib/types";
-import { CG } from "./lib/data";
 import type { Format } from "./lib/format";
 import type { DownloadOptions } from "./components/SettingsModal";
 import { DEFAULT_SETTINGS, type GenerateSettings } from "./worker/types";
 
 type Route = { view: "empty" | "library" | "editor"; initial: Template | null };
+type UploadedPart = { file: File; content: string };
 
 function routeFromHash(): Route {
   const h = (location.hash || "").replace(/^#\/?/, "");
@@ -49,19 +49,18 @@ function formatFromFileName(name: string): Format {
   return "toml";
 }
 
-function uploadedTemplate(file: File, content: string, kind: "config" | "template"): Template {
-  const isConfig = kind === "config";
+function uploadedTemplate(config: UploadedPart, template: UploadedPart): Template {
   return {
-    id: `uploaded-${kind}`,
-    name: file.name,
-    desc: "アップロードしたファイルから作成した一時ドキュメント。",
+    id: "uploaded-files",
+    name: `${config.file.name} + ${template.file.name}`,
+    desc: "アップロードした2つのファイルから作成した一時ドキュメント。",
     category: "network",
-    format: isConfig ? formatFromFileName(file.name) : "toml",
+    format: formatFromFileName(config.file.name),
     output: "markdown",
     updated: new Date().toISOString().slice(0, 10),
     live: true,
-    data: isConfig ? content : CG.configToml,
-    template: isConfig ? CG.templateJ2 : content,
+    data: config.content,
+    template: template.content,
   };
 }
 
@@ -92,6 +91,9 @@ export function App() {
   const [download, setDownload] = React.useState<DownloadOptions>(DEFAULT_DOWNLOAD);
   const [draftTemplate, setDraftTemplate] = React.useState<Template | null>(null);
   const [uploadError, setUploadError] = React.useState<string | null>(null);
+  const [uploadedConfig, setUploadedConfig] = React.useState<UploadedPart | null>(null);
+  const [uploadedJinjaTemplate, setUploadedJinjaTemplate] = React.useState<UploadedPart | null>(null);
+  const uploadVersionRef = React.useRef<Record<"config" | "template", number>>({ config: 0, template: 0 });
 
   React.useEffect(() => {
     const on = () => setRoute(routeFromHash());
@@ -102,20 +104,46 @@ export function App() {
   const go = (hash: string) => { location.hash = hash; };
   const back = () => history.back();
   const openEditor = (tpl: Template | null) => {
+    uploadVersionRef.current.config += 1;
+    uploadVersionRef.current.template += 1;
     setDraftTemplate(null);
     setUploadError(null);
+    setUploadedConfig(null);
+    setUploadedJinjaTemplate(null);
     go(tpl ? "#/t/" + encodeURIComponent(tpl.id) : "#/new");
   };
   const openUploadedFile = async (file: File, kind: "config" | "template") => {
+    const uploadVersion = uploadVersionRef.current[kind] + 1;
+    uploadVersionRef.current[kind] = uploadVersion;
     try {
       const content = await readFileText(file);
+      if (uploadVersionRef.current[kind] !== uploadVersion) return;
       setUploadError(null);
-      setDraftTemplate(uploadedTemplate(file, content, kind));
-      go("#/new");
+      const uploaded = { file, content };
+      if (kind === "config") setUploadedConfig(uploaded);
+      else setUploadedJinjaTemplate(uploaded);
     } catch {
+      if (uploadVersionRef.current[kind] !== uploadVersion) return;
+      if (kind === "config") setUploadedConfig(null);
+      else setUploadedJinjaTemplate(null);
       setUploadError(`${file.name} を読み込めませんでした。別のファイルを選択してください。`);
     }
   };
+  const handleUploadError = (kind: "config" | "template", message: string) => {
+    uploadVersionRef.current[kind] += 1;
+    if (kind === "config") setUploadedConfig(null);
+    else setUploadedJinjaTemplate(null);
+    setUploadError(message);
+  };
+
+  React.useEffect(() => {
+    if (route.view !== "empty" || !uploadedConfig || !uploadedJinjaTemplate) return;
+    setDraftTemplate(uploadedTemplate(uploadedConfig, uploadedJinjaTemplate));
+    setUploadedConfig(null);
+    setUploadedJinjaTemplate(null);
+    setUploadError(null);
+    go("#/new");
+  }, [route.view, uploadedConfig, uploadedJinjaTemplate]);
 
   const editorInitial = route.initial || draftTemplate;
 
@@ -138,8 +166,11 @@ export function App() {
         onLibrary={() => go("#/library")}
         onConfigFile={(file) => void openUploadedFile(file, "config")}
         onTemplateFile={(file) => void openUploadedFile(file, "template")}
-        onUploadError={setUploadError}
+        onConfigUploadError={(message) => handleUploadError("config", message)}
+        onTemplateUploadError={(message) => handleUploadError("template", message)}
         uploadError={uploadError}
+        configFileName={uploadedConfig?.file.name || null}
+        templateFileName={uploadedJinjaTemplate?.file.name || null}
       />
     );
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ import { DEFAULT_SETTINGS, type GenerateSettings } from "./worker/types";
 
 type Route = { view: "empty" | "library" | "editor"; initial: Template | null };
 type UploadedPart = { file: File; content: string };
+type UploadKind = "config" | "template";
 
 function routeFromHash(): Route {
   const h = (location.hash || "").replace(/^#\/?/, "");
@@ -90,10 +91,10 @@ export function App() {
   const [settings, setSettings] = React.useState<GenerateSettings>(DEFAULT_SETTINGS);
   const [download, setDownload] = React.useState<DownloadOptions>(DEFAULT_DOWNLOAD);
   const [draftTemplate, setDraftTemplate] = React.useState<Template | null>(null);
-  const [uploadError, setUploadError] = React.useState<string | null>(null);
+  const [uploadErrors, setUploadErrors] = React.useState<Record<UploadKind, string | null>>({ config: null, template: null });
   const [uploadedConfig, setUploadedConfig] = React.useState<UploadedPart | null>(null);
   const [uploadedJinjaTemplate, setUploadedJinjaTemplate] = React.useState<UploadedPart | null>(null);
-  const uploadVersionRef = React.useRef<Record<"config" | "template", number>>({ config: 0, template: 0 });
+  const uploadVersionRef = React.useRef<Record<UploadKind, number>>({ config: 0, template: 0 });
 
   React.useEffect(() => {
     const on = () => setRoute(routeFromHash());
@@ -107,18 +108,18 @@ export function App() {
     uploadVersionRef.current.config += 1;
     uploadVersionRef.current.template += 1;
     setDraftTemplate(null);
-    setUploadError(null);
+    setUploadErrors({ config: null, template: null });
     setUploadedConfig(null);
     setUploadedJinjaTemplate(null);
     go(tpl ? "#/t/" + encodeURIComponent(tpl.id) : "#/new");
   };
-  const openUploadedFile = async (file: File, kind: "config" | "template") => {
+  const openUploadedFile = async (file: File, kind: UploadKind) => {
     const uploadVersion = uploadVersionRef.current[kind] + 1;
     uploadVersionRef.current[kind] = uploadVersion;
     try {
       const content = await readFileText(file);
       if (uploadVersionRef.current[kind] !== uploadVersion) return;
-      setUploadError(null);
+      setUploadErrors((current) => ({ ...current, [kind]: null }));
       const uploaded = { file, content };
       if (kind === "config") setUploadedConfig(uploaded);
       else setUploadedJinjaTemplate(uploaded);
@@ -126,14 +127,17 @@ export function App() {
       if (uploadVersionRef.current[kind] !== uploadVersion) return;
       if (kind === "config") setUploadedConfig(null);
       else setUploadedJinjaTemplate(null);
-      setUploadError(`${file.name} を読み込めませんでした。別のファイルを選択してください。`);
+      setUploadErrors((current) => ({
+        ...current,
+        [kind]: `${file.name} を読み込めませんでした。別のファイルを選択してください。`,
+      }));
     }
   };
-  const handleUploadError = (kind: "config" | "template", message: string) => {
+  const handleUploadError = (kind: UploadKind, message: string) => {
     uploadVersionRef.current[kind] += 1;
     if (kind === "config") setUploadedConfig(null);
     else setUploadedJinjaTemplate(null);
-    setUploadError(message);
+    setUploadErrors((current) => ({ ...current, [kind]: message }));
   };
 
   React.useEffect(() => {
@@ -141,7 +145,7 @@ export function App() {
     setDraftTemplate(uploadedTemplate(uploadedConfig, uploadedJinjaTemplate));
     setUploadedConfig(null);
     setUploadedJinjaTemplate(null);
-    setUploadError(null);
+    setUploadErrors({ config: null, template: null });
     go("#/new");
   }, [route.view, uploadedConfig, uploadedJinjaTemplate]);
 
@@ -168,7 +172,7 @@ export function App() {
         onTemplateFile={(file) => void openUploadedFile(file, "template")}
         onConfigUploadError={(message) => handleUploadError("config", message)}
         onTemplateUploadError={(message) => handleUploadError("template", message)}
-        uploadError={uploadError}
+        uploadError={uploadErrors.config || uploadErrors.template}
         configFileName={uploadedConfig?.file.name || null}
         templateFileName={uploadedJinjaTemplate?.file.name || null}
       />

--- a/web/src/components/EmptyState.tsx
+++ b/web/src/components/EmptyState.tsx
@@ -100,11 +100,28 @@ export interface EmptyStateProps {
   onConfigFile?: (file: File) => void;
   onTemplateFile?: (file: File) => void;
   onUploadError?: (message: string) => void;
+  onConfigUploadError?: (message: string) => void;
+  onTemplateUploadError?: (message: string) => void;
   uploadError?: string | null;
+  configFileName?: string | null;
+  templateFileName?: string | null;
 }
 
-export function EmptyState({ onStart, onLibrary, onConfigFile, onTemplateFile, onUploadError, uploadError }: EmptyStateProps) {
+export function EmptyState({
+  onStart,
+  onLibrary,
+  onConfigFile,
+  onTemplateFile,
+  onUploadError,
+  onConfigUploadError,
+  onTemplateUploadError,
+  uploadError,
+  configFileName,
+  templateFileName,
+}: EmptyStateProps) {
   const [howto, setHowto] = useState(false);
+  const reportConfigUploadError = onConfigUploadError || onUploadError;
+  const reportTemplateUploadError = onTemplateUploadError || onUploadError;
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: 'var(--cg-bg)', fontFamily: 'var(--font-sans)', color: 'var(--cg-text)', position: 'relative', overflow: 'hidden' }}>
 
@@ -214,14 +231,16 @@ export function EmptyState({ onStart, onLibrary, onConfigFile, onTemplateFile, o
                 accept=".toml,.yaml,.yml,.csv"
                 acceptLabel="TOML, YAML, CSV"
                 onFile={onConfigFile}
-                onError={onUploadError}
+                onError={reportConfigUploadError}
+                fileName={configFileName}
               />
               <FileUploader
                 label="② Jinjaテンプレート"
                 accept=".j2,.jinja2"
                 acceptLabel="J2, JINJA2"
                 onFile={onTemplateFile}
-                onError={onUploadError}
+                onError={reportTemplateUploadError}
+                fileName={templateFileName}
               />
             </div>
 


### PR DESCRIPTION
## Summary
- Keep the initial upload screen open until both the config file and Jinja template are uploaded successfully.
- Show selected upload file names on the initial screen.
- Keep upload-stage errors on the initial screen and clear only the affected upload slot.
- Guard async file reads so stale reads cannot overwrite a newer file selection.

## Root cause
The web upload handler navigated to the editor as soon as either upload slot finished reading. That made the two-file onboarding flow feel surprising and also allowed stale async reads to win if users selected files quickly.

## Validation
- npm test -- App.test.tsx
- npm test
- npm run build

## Notes
Build succeeds with the existing Vite chunk size warning.