### PR TITLE
revert: restore develop CI integration (undo #484); keep #367 dependabot key fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,8 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/ja/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 #
-# NOTE: develop ブランチはリタイア済み。Dependabot はデフォルトブランチ (main)
-# を対象とする (target-branch を指定しない = デフォルトブランチ)。
-# `security-updates` は dependabot.yml の有効キーではないため削除した
-# (セキュリティ更新はリポジトリ設定側で有効化する)。Refs #367。
+# NOTE: `security-updates` は dependabot.yml の有効キーではないため使用しない
+# (セキュリティ更新はリポジトリ設定側で有効化する)。Refs #367.
 ---
 version: 2
 updates:
@@ -23,6 +21,7 @@ updates:
       interval: daily
       time: "18:00"
       timezone: "Asia/Tokyo"
+    target-branch: develop
 
   - package-ecosystem: npm
     directory: /
@@ -34,6 +33,7 @@ updates:
       interval: daily
       time: "19:00"
       timezone: "Asia/Tokyo"
+    target-branch: develop
 
   - package-ecosystem: pip
     directory: /
@@ -45,6 +45,7 @@ updates:
       interval: daily
       time: "20:00"
       timezone: "Asia/Tokyo"
+    target-branch: develop
 
   - package-ecosystem: devcontainers
     directory: /
@@ -56,3 +57,4 @@ updates:
       interval: daily
       time: "21:00"
       timezone: "Asia/Tokyo"
+    target-branch: develop

--- a/.github/workflows/test-and-build-on-pr-skip.yml
+++ b/.github/workflows/test-and-build-on-pr-skip.yml
@@ -40,6 +40,7 @@ on:
   pull_request:
     branches:
       - main
+      - develop
     paths:
       - .cursor/**
       - .devcontainer/**

--- a/.github/workflows/test-and-build-on-pr.yml
+++ b/.github/workflows/test-and-build-on-pr.yml
@@ -4,14 +4,14 @@
 #
 # ワークフローの目的 (Purpose):
 # -----------------------------
-# main ブランチに対する Pull Request (オープン、同期、再オープン、編集)
+# main または develop ブランチに対する Pull Request (オープン、同期、再オープン、編集)
 # をトリガーとして実行されます。PR のコードに対してテスト、ビルド、ベンチマーク、
 # および追加のセキュリティチェック (OSS Scorecards, Dependency Review) を実行します。
 # Dependabot による PR の場合、テストが成功すれば自動的に承認します。
 #
 # ワークフローの影響範囲 (Scope of Impact):
 # ---------------------------------------
-# - main ブランチへのマージ前のコード品質を検証します。
+# - main および develop ブランチへのマージ前のコード品質を検証します。
 # - Pull Request にテスト結果、ベンチマーク結果、セキュリティレビュー結果をコメントとして投稿する可能性があります。
 # - Dependabot PR を自動承認することがあります。
 # - OpenSSF Scorecards の結果を Security タブにアップロードします。
@@ -45,6 +45,7 @@ on:
   pull_request:
     branches:
       - main
+      - develop
     paths-ignore:
       - .cursor/**
       - .devcontainer/**

--- a/.github/workflows/test-and-build-on-push.yml
+++ b/.github/workflows/test-and-build-on-push.yml
@@ -1,0 +1,469 @@
+# ============================================================
+# Workflow Information: test-and-build-on-push.yml
+# ============================================================
+#
+# ワークフローの目的 (Purpose):
+# -----------------------------
+# develop ブランチへのプッシュをトリガーとして実行されます。
+# 最新の develop ブランチのコードに対してテストとビルドを実行し、
+# develop ブランチのバージョンが main ブランチのバージョンよりも新しい場合、
+# main ブランチへの Pull Request を自動的に作成します。
+# 特定のファイルパスの変更は無視されます。
+#
+# ワークフローの影響範囲 (Scope of Impact):
+# ---------------------------------------
+# - develop ブランチのコード品質を検証します。
+# - リポジトリに新しい Pull Request を作成する可能性があります (develop -> main)。
+# - PR 作成時には、必要なラベル ("automated-pr", "release") が存在しない場合に自動作成します。
+# - 既存のオープンな PR (develop -> main) がある場合、または同じバージョンのリリース PR が既に存在する場合は、新規 PR 作成をスキップします。
+#
+# 依存する外部のワークフロー (External Dependencies):
+# ------------------------------------------------
+# - ./.github/workflows/reusable-test-and-build.yml (テストとビルドのコアロジック)
+# - 複数の外部 GitHub Actions (Harden Runner, Checkout, NPM Version, Semver Utils, GitHub Script)
+#
+# セキュリティポリシー (Security Policy):
+# ------------------------------------
+# - `permissions` キーでワークフローの権限を最小限に制限しています (PR 作成のために contents: write, pull-requests: write が必要)。
+# - `step-security/harden-runner` を使用してランナーのセキュリティを強化しています (egress-policy: block)。
+# - PR 作成ジョブ (`create-pr-to-main`) は、テストジョブ (`test-and-build`) の成功を条件とします。
+# - バージョン比較 (`madhead/semver-utils`) を行い、develop が main より新しい場合にのみ PR を作成します。
+# - PR 作成前に既存の PR をチェックし、重複を防ぎます。
+# - GitHub Script 内で GitHub API を利用して PR 作成やラベル操作を行いますが、スクリプトの実行権限は制限されています。
+#
+# 参考URL (Reference URLs):
+# -------------------------
+# - GitHub Actions Documentation: https://docs.github.com/ja/actions
+# - Reusable Workflow: ./.github/workflows/reusable-test-and-build.yml
+# - GitHub Script Action: https://github.com/actions/github-script
+# - Semver Utils Action: https://github.com/madhead/semver-utils
+#
+# ============================================================
+---
+name: Test and Build - on push to develop
+
+on:
+  push:
+    branches:
+      - develop
+    paths-ignore:
+      - .cursor/**
+      - .devcontainer/**
+      - assets/**
+      - docs/**
+      - .github/workflows/test-and-build-on-merged.yml
+      - .github/workflows/test-and-build-on-pr.yml
+      - .gitignore
+      - .pre-commit-config.yaml
+      - .watchmanconfig
+      - .yamllint.yml
+      - "**.code-workspace"
+      - commitlint.config.js
+      - LICENSE
+      - README.md
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  GLOBAL_PYTHON_VERSION: ${{ vars.GLOBAL_PYTHON_VERSION }}
+  HARDEN_RUNNER_EGRESS_POLICY: block
+
+permissions:
+  actions: write
+  contents: read
+  checks: write
+  id-token: write
+  issues: write
+  security-events: write
+
+jobs:
+  test-and-build:
+    uses: ./.github/workflows/reusable-test-and-build.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    with:
+      concurrency_group: push-${{ github.workflow }}-${{ github.ref }}
+      concurrency_cancel_in_progress: true
+      workflow_summary_name: "Workflow summary [Test & Build (on push to develop)]"
+
+  get-develop-npm-version:
+    outputs:
+      version: ${{ steps.set-versions.outputs.develop_version }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          disable-sudo: true
+          allowed-endpoints: >
+            github.com:443
+
+      - name: Checkout develop branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: develop
+          fetch-depth: 1
+
+      - name: Get version from develop
+        id: get-dev-ver
+        uses: martinbeentjes/npm-get-version-action@3cf273023a0dda27efcd3164bdfb51908dd46a5b # v1.3.1
+
+      - name: Set versions output
+        id: set-versions
+        run: |
+          echo "Develop version: ${{ steps.get-dev-ver.outputs.current-version }}"
+          echo "develop_version=${{ steps.get-dev-ver.outputs.current-version }}" >> "$GITHUB_OUTPUT"
+
+  get-main-npm-version:
+    outputs:
+      version: ${{ steps.set-versions.outputs.main_version }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          disable-sudo: true
+          allowed-endpoints: >
+            github.com:443
+
+      - name: Checkout main branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Get version from main
+        id: get-main-ver
+        uses: martinbeentjes/npm-get-version-action@3cf273023a0dda27efcd3164bdfb51908dd46a5b # v1.3.1
+
+      - name: Set versions output
+        id: set-versions
+        run: |
+          echo "Main version: ${{ steps.get-main-ver.outputs.current-version }}"
+          echo "main_version=${{ steps.get-main-ver.outputs.current-version }}" >> "$GITHUB_OUTPUT"
+
+  create-pr-to-main:
+    needs:
+      - test-and-build
+      - get-develop-npm-version
+      - get-main-npm-version
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
+          disable-sudo: true
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Dump GitHub context # Keep for potential debugging/context needs within the action
+        id: github_context_step
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT" | jq -r '. | {event_name, workflow_ref, repository, run_id, run_number}'
+
+      - name: Compare versions (Semver)
+        uses: madhead/semver-utils@36d1e0ed361bd7b4b77665de8093092eaeabe6ba # v4.3.0
+        id: compare-versions
+        with:
+          version: ${{ needs.get-develop-npm-version.outputs.version }}
+          compare-to: ${{ needs.get-main-npm-version.outputs.version }}
+
+      - name: Check if PR already exists and check for duplicate title
+        id: check-pr
+        if: steps.compare-versions.outputs.comparison-result == '>'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const developVersion = "${{ needs.get-develop-npm-version.outputs.version }}";
+            const expectedTitle = `Release: v${developVersion}`;
+            let prExists = false;
+            let titleExists = false;
+
+            try {
+              const pulls = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head: `${context.repo.owner}:develop`, // Assuming develop is always the head
+                base: 'main',                       // Assuming main is always the base
+                state: 'open'
+              });
+
+              if (pulls.data.length > 0) {
+                prExists = true;
+                // Check if any existing PR has the target title
+                titleExists = pulls.data.some(pr => pr.title === expectedTitle);
+              }
+
+              console.log(`Expected PR Title: ${expectedTitle}`);
+              console.log(`Existing open PRs from develop to main: ${pulls.data.length}`);
+              console.log(`Any open PR exists? ${prExists}`);
+              console.log(`Open PR with title "${expectedTitle}" exists? ${titleExists}`);
+              console.log(prExists.toString());
+
+              core.setOutput('pr_exists', prExists.toString());
+              core.setOutput('title_exists', titleExists.toString());
+              core.setOutput('success', 'true');
+            } catch (error) {
+              console.error(`Error checking for existing PRs: ${error.message}`);
+              core.setOutput('pr_exists', ''); // Indicate failure
+              core.setOutput('title_exists', ''); // Indicate failure
+              core.setOutput('success', 'false');
+              core.setFailed(`Error checking for existing PRs: ${error.message}`);
+            }
+
+      - name: Ensure labels exist
+        id: ensure-labels
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let allLabelsEnsured = true;
+            const requiredLabels = [
+              { name: "automated-pr", description: "Automatically generated PR", color: "0E8A16" },
+              { name: "release", description: "PR for automated release", color: "1D76DB" }
+            ];
+
+            async function ensureLabel(labelInfo) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: labelInfo.name
+                });
+                console.log(`Label '${labelInfo.name}' already exists.`);
+                return true;
+              } catch (error) {
+                if (error.status === 404) {
+                  console.log(`Label '${labelInfo.name}' does not exist. Creating...`);
+                  try {
+                    await github.rest.issues.createLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: labelInfo.name,
+                      description: labelInfo.description,
+                      color: labelInfo.color
+                    });
+                    console.log(`Label '${labelInfo.name}' created successfully.`);
+                    return true;
+                  } catch (createError) {
+                    console.error(`Failed to create label '${labelInfo.name}': ${createError.message}`);
+                    allLabelsEnsured = false;
+                    return false;
+                  }
+                } else {
+                  console.error(`Error checking label '${labelInfo.name}': ${error.message}`);
+                  allLabelsEnsured = false;
+                  return false;
+                }
+              }
+            }
+
+            console.log("::notice::Ensuring required labels exist...");
+            for (const label of requiredLabels) {
+              await ensureLabel(label);
+            }
+
+            if (allLabelsEnsured) {
+              console.log("All required labels exist or were created.");
+              core.setOutput('success', 'true');
+            } else {
+              console.error("Failed to ensure one or more required labels.");
+              core.setOutput('success', 'false');
+              core.setFailed("Failed to ensure one or more required labels.");
+            }
+
+      # Setup Python required by the create_pr.py script
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ env.GLOBAL_PYTHON_VERSION }}
+
+      - name: Get commit log
+        id: commit_log
+        run: |
+          echo "以下のコミットが含まれています:" > .commit-log.txt
+          echo "" >> .commit-log.txt
+          git log origin/main..HEAD --pretty=format:"- %s" --no-merges >> .commit-log.txt
+
+      - name: Display version comparison result # Optional: for debugging
+        run: |
+          echo "Comparison Result: ${{ steps.compare-versions.outputs.comparison-result }}"
+          echo "Check PR Success: ${{ steps.check-pr.outputs.success }}"
+          echo "Check PR Exists: ${{ steps.check-pr.outputs.pr_exists }}"
+          echo "Check PR Title Exists: ${{ steps.check-pr.outputs.title_exists }}"
+          echo "Ensure Labels Success: ${{ steps.ensure-labels.outputs.success }}"
+          echo "Show commit log: $(cat .commit-log.txt)"
+
+      - name: Create Pull Request using github-script
+        id: create-pr-script
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        if: |
+          steps.compare-versions.outputs.comparison-result == '>' &&
+          steps.check-pr.outputs.success == 'true' &&
+          steps.check-pr.outputs.pr_exists == 'false' &&
+          steps.check-pr.outputs.title_exists == 'false' &&
+          steps.ensure-labels.outputs.success == 'true'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const developVersion = "${{ needs.get-develop-npm-version.outputs.version }}";
+            const commitLogPath = '.commit-log.txt';
+            let commitLogContent = '';
+            try {
+              commitLogContent = fs.readFileSync(commitLogPath, 'utf8');
+              console.log(`Successfully read commit log from ${commitLogPath}`);
+            } catch (error) {
+              console.error(`Error reading commit log file ${commitLogPath}: ${error.message}`);
+              core.setFailed(`Failed to read commit log: ${error.message}`);
+              return; // Stop execution if commit log cannot be read
+            }
+
+            const prOptions = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Release: v${developVersion}`,
+              head: 'develop',
+              base: 'main',
+              body: commitLogContent,
+              maintainer_can_modify: true,
+              draft: false
+            };
+
+            try {
+              console.log(`Attempting to create pull request: ${prOptions.title}`);
+              const { data: pullRequest } = await github.rest.pulls.create(prOptions);
+              console.log(`Successfully created pull request #${pullRequest.number}: ${pullRequest.html_url}`);
+              core.setOutput('pr_url', pullRequest.html_url);
+              core.setOutput('outcome', 'success');
+
+              // Add labels to the created PR
+              try {
+                const labels = ['release', 'automated-pr'];
+                console.log(`Adding labels (${labels.join(', ')}) to PR #${pullRequest.number}`);
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pullRequest.number,
+                  labels: labels
+                });
+                console.log('Labels added successfully.');
+              } catch (labelError) {
+                console.error(`Failed to add labels to PR #${pullRequest.number}: ${labelError.message}`);
+                // Continue even if adding labels fails, but log the error
+              }
+
+            } catch (error) {
+              console.error(`Failed to create pull request: ${error.message}`);
+              core.setOutput('outcome', 'error');
+              core.setOutput('pr_url', '');
+              core.setFailed(`Failed to create pull request: ${error.message}`);
+            }
+        env:
+          DEVELOP_VERSION: ${{ needs.get-develop-npm-version.outputs.version }}
+
+      - name: Set Final Status
+        id: set-status
+        # Always run this step to report the final status
+        if: always()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const compareResult = "${{ steps.compare-versions.outputs.comparison-result }}";
+            const checkPrSuccess = "${{ steps.check-pr.outputs.success }}";
+            const checkPrExists = "${{ steps.check-pr.outputs.pr_exists }}";
+            const checkPrTitleExists = "${{ steps.check-pr.outputs.title_exists }}";
+            const ensureLabelsSuccess = "${{ steps.ensure-labels.outputs.success }}";
+            // Use the outcome and URL from the new script step
+            const createPrOutcome = "${{ steps.create-pr-script.outputs.outcome }}";
+            const createPrUrl = "${{ steps.create-pr-script.outputs.pr_url }}";
+            const developVersion = "${{ needs.get-develop-npm-version.outputs.version }}";
+            const mainVersion = "${{ needs.get-main-npm-version.outputs.version }}";
+
+            let status = "unknown"; // Default status
+            let prUrl = createPrUrl || "";
+
+            core.info(
+              `Initial evaluation: compareResult='${compareResult}', ` +
+              `checkPrSuccess='${checkPrSuccess}', checkPrExists='${checkPrExists}', ` +
+              `checkPrTitleExists='${checkPrTitleExists}', ensureLabelsSuccess='${ensureLabelsSuccess}', ` +
+              `createPrOutcome='${createPrOutcome}'`
+            );
+
+            if (compareResult === '>') {
+              if (checkPrSuccess === 'true') {
+                if (checkPrTitleExists === 'true') {
+                  status = "skipped_title_exists";
+                  core.info(`Status update: PR with the same title already exists (title_exists=${checkPrTitleExists}). Setting status to '${status}'.`);
+                } else if (checkPrExists !== '0') {
+                  status = "exists";
+                  core.info(`Status update: PR already exists (checkPrExists=${checkPrExists}). Setting status to '${status}'.`);
+                } else { // No existing PR with this title or any PR at all
+                  if (ensureLabelsSuccess === 'true') {
+                    // Check the outcome of the create-pr-script step
+                    if (createPrOutcome === 'success') {
+                      status = "created";
+                      core.info(`Status update: PR creation successful. Setting status to '${status}' and pr_url.`);
+                    } else if (createPrOutcome === 'error') {
+                      status = "error_create_pr";
+                      core.error(`Create PR script failed. Setting status to '${status}'.`);
+                    } else {
+                      // This case should ideally not happen if the script step ran
+                      status = "skipped_create_pr_script"; // Indicates the script step itself was skipped or didn't output 'success'/'error'
+                      core.warning(`Create PR script outcome was neither 'success' nor 'error' ('${createPrOutcome}'). Setting status to '${status}'.`);
+                    }
+                  } else { // ensure-labels failed
+                    status = "skipped_label_fail";
+                    core.error(`Ensure Labels step failed (success: ${ensureLabelsSuccess}). Setting status to '${status}'.`);
+                  }
+                }
+              } else { // check-pr failed
+                status = "error_check_pr";
+                core.error(`Check PR step failed (success: ${checkPrSuccess}). Setting status to '${status}'.`);
+              }
+            } else { // Version comparison did not result in '>'
+              core.info(`Skipping PR creation: develop version (${developVersion}) is not greater than main version (${mainVersion}). Comparison result: ${compareResult}`);
+              status = "skipped_version_compare";
+            }
+
+            // Override status if the create-pr-script step was explicitly skipped by its 'if' condition
+            if (compareResult !== '>' || checkPrSuccess !== 'true' || checkPrExists !== '0' || checkPrTitleExists !== 'false' || ensureLabelsSuccess !== 'true') {
+                if (status === 'unknown' || status === 'exists') { // Only override if not already set by inner logic or if it's the general 'exists'
+                    status = 'skipped_precondition_fail';
+                    core.info(`Create PR script step preconditions not met. Setting status to '${status}'.`);
+                }
+            }
+
+            core.info(`Final Status determined: ${status}`);
+            core.setOutput('status', status);
+            core.setOutput('pr_url', prUrl);
+
+            // Log errors based on status
+            if (status.startsWith('error_') || status === 'skipped_label_fail') {
+              core.error(`Workflow action encountered an issue: ${status}`);
+            }

--- a/.github/workflows/test-and-build-on-push.yml
+++ b/.github/workflows/test-and-build-on-push.yml
@@ -171,6 +171,9 @@ jobs:
         with:
           egress-policy: ${{ env.HARDEN_RUNNER_EGRESS_POLICY }}
           disable-sudo: true
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/verify-superpowers.yml
+++ b/.github/workflows/verify-superpowers.yml
@@ -13,7 +13,7 @@
 #
 # 影響範囲 (Scope of Impact):
 # ---------------------------
-# - main への PR・push で superpowers スキルの陳腐化を検証する。
+# - main / develop への PR・push で superpowers スキルの陳腐化を検証する。
 # - リポジトリへの書き込みは行わない (contents: read)。
 #
 # セキュリティ (Security):
@@ -34,6 +34,7 @@ on:
   pull_request:
     branches:
       - main
+      - develop
     paths:
       - .claude/skills/**
       - apm.yml
@@ -43,6 +44,7 @@ on:
   push:
     branches:
       - main
+      - develop
     paths:
       - .claude/skills/**
       - apm.yml


### PR DESCRIPTION
## 背景

develop 継続方針の再確認により、PR #484（develop 退役決定 #483 に基づく変更）を取り消します。詳細は #489 参照。

## 変更内容

`3dfa801`（#484）を revert しつつ、`security-updates: true`（#367で無効キーと判明）の除去のみは維持:

- 復元: `verify-superpowers.yml` / `test-and-build-on-pr.yml` / `test-and-build-on-pr-skip.yml` の `develop` トリガー
- 復元: `test-and-build-on-push.yml`（develop→main リリースPR自動生成ワークフロー）
- 復元: `dependabot.yml` の `target-branch: develop`（4エコシステム）
- 維持: `dependabot.yml` から `security-updates: true` を除去したまま（#367対応）

## 関連

- Closes #489
- #483（develop退役決定）はクローズ済みのまま維持。決定が覆った旨は#483へコメント済み。
- #486（#484のレトロスペクティブ）は新規レトロissueを起票せず、本PRマージ後にレビューをコメント記録する（CLAUDE.local.md準拠）。
- developをmainの現行アーキテクチャへ再構築する方針は #490 で記録済み（実行は別途）。

## Verification

- `yamllint -c .yamllint.yml` で対象5ファイル exit 0 を確認済み。
- 復元後の内容を目視確認し、`security-updates: true` が再導入されていないことを確認済み。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BLHUMn5o8efGyJi49G7oxM)_