### PR TITLE
feat: add AI-infrastructure template series (DGX Spark + ollama, zero-trust access) (#494)

### DIFF
--- a/assets/examples/dgx-spark-ollama.j2
+++ b/assets/examples/dgx-spark-ollama.j2
@@ -1,0 +1,76 @@
+# DGX Spark AIマシン初期セットアップ手順 — {{ hostname }}
+
+NVIDIA DGX Spark 上に ollama による LLM 推論サーバを構築する手順です。DGX OS の初回起動ウィザード完了後を前提に、sudo 権限で上から順に実行してください。IaC は使わず、すべて CLI で完結します。
+
+## 1. ホスト名・タイムゾーン・パッケージ更新
+
+```bash
+sudo hostnamectl set-hostname {{ hostname }}
+sudo timedatectl set-timezone {{ timezone }}
+sudo apt-get update && sudo apt-get upgrade -y
+```
+
+## 2. SSH を堅牢化する
+
+```bash
+{% if not ssh.permit_root_login %}sudo sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
+{% endif %}{% if not ssh.password_auth %}sudo sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+{% endif %}sudo systemctl reload ssh
+```
+
+> パスワード認証を切る前に、鍵での SSH ログインができることを必ず確認してください。
+
+## 3. ファイアウォールを有効化する（LAN 限定公開）
+
+```bash
+sudo ufw default deny incoming
+sudo ufw allow from {{ lan_subnet }} to any port 22 proto tcp
+sudo ufw allow from {{ lan_subnet }} to any port {{ ollama.port }} proto tcp
+sudo ufw --force enable
+```
+
+## 4. GPU を確認する
+
+DGX OS はドライバ・CUDA が導入済みです。GPU が認識されていることだけ確認します。
+
+```bash
+nvidia-smi
+```
+
+## 5. ollama をインストールする
+
+```bash
+curl -fsSL https://ollama.com/install.sh | sh
+```
+
+## 6. LAN 内 API 公開の設定（systemd オーバーライド）
+
+既定ではループバックのみ待ち受けるため、LAN 内クライアントから使えるように上書きします。
+
+```bash
+sudo mkdir -p /etc/systemd/system/ollama.service.d
+sudo tee /etc/systemd/system/ollama.service.d/override.conf <<'EOF'
+[Service]
+Environment="OLLAMA_HOST=0.0.0.0:{{ ollama.port }}"
+Environment="OLLAMA_KEEP_ALIVE={{ ollama.keep_alive }}"
+EOF
+sudo systemctl daemon-reload
+sudo systemctl enable --now ollama
+```
+
+## 7. モデルを取得する
+
+```bash
+{% for m in ollama.models %}ollama pull {{ m.name }}  # {{ m.purpose }}
+{% endfor %}```
+
+## 8. 動作確認
+
+```bash
+ollama list
+curl http://127.0.0.1:{{ ollama.port }}/api/version
+{% for c in clients %}# {{ c.name }} ({{ c.ip }}) から:
+curl http://{{ hostname }}:{{ ollama.port }}/api/version
+{% endfor %}```
+
+> ここまでで API は LAN 内に平文 HTTP で公開されています。商用運用では「ゼロトラストアクセス基盤構築」テンプレートで mTLS 化してください。

--- a/assets/examples/dgx-spark-ollama.j2
+++ b/assets/examples/dgx-spark-ollama.j2
@@ -22,11 +22,13 @@ sudo apt-get update && sudo apt-get upgrade -y
 
 ## 3. ファイアウォールを有効化する（LAN 限定公開）
 
+SSH は LAN 全体から、API は許可するクライアント単位で開けます。
+
 ```bash
 sudo ufw default deny incoming
 sudo ufw allow from {{ lan_subnet }} to any port 22 proto tcp
-sudo ufw allow from {{ lan_subnet }} to any port {{ ollama.port }} proto tcp
-sudo ufw --force enable
+{% for c in clients %}sudo ufw allow from {{ c.ip }} to any port {{ ollama.port }} proto tcp   # {{ c.name }}
+{% endfor %}sudo ufw --force enable
 ```
 
 ## 4. GPU を確認する
@@ -45,7 +47,7 @@ curl -fsSL https://ollama.com/install.sh | sh
 
 ## 6. LAN 内 API 公開の設定（systemd オーバーライド）
 
-既定ではループバックのみ待ち受けるため、LAN 内クライアントから使えるように上書きします。
+既定ではループバックのみ待ち受けるため、LAN 内クライアントから使えるように上書きします。インストーラがサービスを起動済みのため、設定反映には再起動が必要です（enable はインストーラが実施済み）。
 
 ```bash
 sudo mkdir -p /etc/systemd/system/ollama.service.d
@@ -55,7 +57,7 @@ Environment="OLLAMA_HOST=0.0.0.0:{{ ollama.port }}"
 Environment="OLLAMA_KEEP_ALIVE={{ ollama.keep_alive }}"
 EOF
 sudo systemctl daemon-reload
-sudo systemctl enable --now ollama
+sudo systemctl restart ollama
 ```
 
 ## 7. モデルを取得する

--- a/assets/examples/dgx-spark-ollama.yaml
+++ b/assets/examples/dgx-spark-ollama.yaml
@@ -1,0 +1,19 @@
+hostname: dgx-spark-01
+timezone: Asia/Tokyo
+lan_subnet: 192.168.10.0/24
+ssh:
+  permit_root_login: false
+  password_auth: false
+ollama:
+  port: 11434
+  keep_alive: 30m
+  models:
+    - name: gpt-oss:120b
+      purpose: 汎用チャット・推論
+    - name: qwen3-coder:30b
+      purpose: コーディング支援
+clients:
+  - name: dev-pc-01
+    ip: 192.168.10.21
+  - name: app-server-01
+    ip: 192.168.10.31

--- a/assets/examples/zero-trust-access.j2
+++ b/assets/examples/zero-trust-access.j2
@@ -13,9 +13,10 @@ AIマシンの API / SSH を、ネットワークの場所ではなく証明書�
 CA は systemd サービスとして常駐させます。フォアグラウンド起動では SSH 切断や再起動で CA が停止し、証明書の発行・更新が止まります。
 
 ```bash
-wget https://dl.smallstep.com/cli/docs-ca-install/latest/step-cli_amd64.deb
-wget https://dl.smallstep.com/certificates/docs-ca-install/latest/step-ca_amd64.deb
-sudo dpkg -i step-cli_amd64.deb step-ca_amd64.deb
+ARCH=$(dpkg --print-architecture)   # amd64 / arm64 を自動判別
+wget https://dl.smallstep.com/cli/docs-ca-install/latest/step-cli_${ARCH}.deb
+wget https://dl.smallstep.com/certificates/docs-ca-install/latest/step-ca_${ARCH}.deb
+sudo dpkg -i step-cli_${ARCH}.deb step-ca_${ARCH}.deb
 sudo useradd --system --home /etc/step-ca --shell /usr/sbin/nologin step
 sudo install -d -m 700 -o step /etc/step-ca
 sudo install -m 600 -o step /dev/null /etc/step-ca/password.txt
@@ -48,8 +49,9 @@ sudo STEPPATH=/etc/step-ca step certificate fingerprint /etc/step-ca/certs/root_
 step CLI と Caddy を導入し、CA に登録します。Caddy は `trust_pool` ディレクティブ（2.8 以降）を使うため、ディストリのパッケージ（Ubuntu 24.04 は 2.6 系）ではなく公式リポジトリから導入します。
 
 ```bash
-wget https://dl.smallstep.com/cli/docs-ca-install/latest/step-cli_amd64.deb
-sudo dpkg -i step-cli_amd64.deb
+ARCH=$(dpkg --print-architecture)   # DGX Spark (GB10) は arm64
+wget https://dl.smallstep.com/cli/docs-ca-install/latest/step-cli_${ARCH}.deb
+sudo dpkg -i step-cli_${ARCH}.deb
 sudo apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl
 curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
 curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
@@ -95,10 +97,11 @@ mTLS ゲートウェイ経由以外の経路が残るとゼロトラストは成
 sudo sed -i 's|^Environment="OLLAMA_HOST=.*|Environment="OLLAMA_HOST=127.0.0.1:11434"|' /etc/systemd/system/ollama.service.d/override.conf
 sudo systemctl daemon-reload
 sudo systemctl restart ollama
-sudo ufw status numbered   # 11434 の allow ルール番号を確認
-sudo ufw delete allow from 192.168.10.21 to any port 11434 proto tcp
-sudo ufw delete allow from 192.168.10.31 to any port 11434 proto tcp
+{% for a in plaintext_allows %}sudo ufw delete allow from {{ a.from }} to any port {{ a.port }} proto tcp
+{% endfor %}sudo ufw status numbered   # 平文経路の allow ルールが残っていないことを確認
 ```
+
+> `plaintext_allows` は dgx-spark-ollama テンプレートで開けたクライアント IP・ポートと一致させてください。ここが一致しないと mTLS を迂回する平文経路が残ります。
 
 ## 5. クライアント証明書を発行する
 

--- a/assets/examples/zero-trust-access.j2
+++ b/assets/examples/zero-trust-access.j2
@@ -1,0 +1,79 @@
+# ゼロトラストアクセス基盤 構築手順 — {{ site }}
+
+AIマシンの API / SSH を、ネットワークの場所ではなく証明書による本人性で保護する構築手順です。商用利用可能な OSS（Smallstep step-ca / Caddy、いずれも Apache-2.0）のみで構成し、IaC は使わず CLI で完結します。
+
+方針:
+
+- **default deny**: 許可した宛先ポート以外はすべて拒否する
+- **場所を信用しない**: LAN 内からのアクセスも mTLS クライアント証明書を要求する
+- **短命クレデンシャル**: SSH は有効期限 {{ ssh.user_cert_validity }} の証明書に置き換える
+
+## 1. プライベート CA を構築する（{{ ca.host }} / {{ ca.ip }}）
+
+```bash
+wget https://dl.smallstep.com/cli/docs-ca-install/latest/step-cli_amd64.deb
+wget https://dl.smallstep.com/certificates/docs-ca-install/latest/step-ca_amd64.deb
+sudo dpkg -i step-cli_amd64.deb step-ca_amd64.deb
+step ca init --name "{{ ca.name }}" --dns {{ ca.host }} --address :8443 --provisioner admin --ssh
+step-ca $(step path)/config/ca.json
+```
+
+> `step ca init` が表示する root 証明書のフィンガープリントを控えてください。以降の全ホストの登録に使います。
+
+## 2. 保護対象サービスの前段に mTLS 終端を置く
+
+{% for s in services %}### {{ s.name }}（{{ s.host }} 上、upstream: {{ s.upstream }}）
+
+```bash
+sudo apt-get install -y caddy
+step ca bootstrap --ca-url https://{{ ca.host }}:8443 --fingerprint <控えたフィンガープリント>
+step ca certificate {{ s.fqdn }} /etc/caddy/{{ s.name }}.crt /etc/caddy/{{ s.name }}.key
+step ca root /etc/caddy/root_ca.crt
+sudo tee /etc/caddy/Caddyfile <<'EOF'
+{{ s.fqdn }}:443 {
+  tls /etc/caddy/{{ s.name }}.crt /etc/caddy/{{ s.name }}.key {
+    client_auth {
+      mode require_and_verify
+      trust_pool file /etc/caddy/root_ca.crt
+    }
+  }
+  reverse_proxy {{ s.upstream }}
+}
+EOF
+sudo systemctl reload caddy
+```
+
+upstream（{{ s.upstream }}）はループバック待ち受けに戻し、直接アクセスを閉じます。
+
+{% endfor %}## 3. ファイアウォールを default deny にする
+
+```bash
+sudo ufw default deny incoming
+{% for port in firewall.allow_tcp %}sudo ufw allow {{ port }}/tcp
+{% endfor %}sudo ufw --force enable
+```
+
+## 4. クライアント証明書を発行する
+
+利用者・端末ごとに短命の証明書を発行します。失効は期限切れ任せにせず `step ca revoke` で行えます。
+
+```bash
+{% for c in clients %}step ca certificate "{{ c.user }}@{{ c.device }}" {{ c.device }}.crt {{ c.device }}.key --not-after {{ c.cert_days * 24 }}h
+{% endfor %}```
+
+## 5. SSH を証明書認証に置き換える
+
+```bash
+step ssh certificate --principal ops ops-key   # 有効期限 {{ ssh.user_cert_validity }}（CA 側 provisioner 設定）
+sudo sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+sudo systemctl reload ssh
+```
+
+## 6. 検証
+
+証明書なしのアクセスが**拒否される**こと、証明書ありが通ることの両方を確認します。
+
+```bash
+curl https://{{ services[0].fqdn }}/api/version --cacert root_ca.crt   # 失敗すること（クライアント証明書なし）
+{% for c in clients %}curl https://{{ services[0].fqdn }}/api/version --cacert root_ca.crt --cert {{ c.device }}.crt --key {{ c.device }}.key   # {{ c.user }}: 成功すること
+{% endfor %}```

--- a/assets/examples/zero-trust-access.j2
+++ b/assets/examples/zero-trust-access.j2
@@ -4,33 +4,77 @@ AIマシンの API / SSH を、ネットワークの場所ではなく証明書�
 
 方針:
 
-- **default deny**: 許可した宛先ポート以外はすべて拒否する
+- **default deny**: 許可した宛先ポート以外はすべて拒否し、平文の直接経路は明示的に閉じる
 - **場所を信用しない**: LAN 内からのアクセスも mTLS クライアント証明書を要求する
 - **短命クレデンシャル**: SSH は有効期限 {{ ssh.user_cert_validity }} の証明書に置き換える
 
-## 1. プライベート CA を構築する（{{ ca.host }} / {{ ca.ip }}）
+## 1. プライベート CA を構築する（{{ ca.host }}）
+
+CA は systemd サービスとして常駐させます。フォアグラウンド起動では SSH 切断や再起動で CA が停止し、証明書の発行・更新が止まります。
 
 ```bash
 wget https://dl.smallstep.com/cli/docs-ca-install/latest/step-cli_amd64.deb
 wget https://dl.smallstep.com/certificates/docs-ca-install/latest/step-ca_amd64.deb
 sudo dpkg -i step-cli_amd64.deb step-ca_amd64.deb
-step ca init --name "{{ ca.name }}" --dns {{ ca.host }} --address :8443 --provisioner admin --ssh
-step-ca $(step path)/config/ca.json
+sudo useradd --system --home /etc/step-ca --shell /usr/sbin/nologin step
+sudo install -d -m 700 -o step /etc/step-ca
+sudo install -m 600 -o step /dev/null /etc/step-ca/password.txt
+openssl rand -base64 24 | sudo tee /etc/step-ca/password.txt >/dev/null
+sudo STEPPATH=/etc/step-ca step ca init --ssh --name "{{ ca.name }}" --dns {{ ca.host }} --address :8443 --provisioner admin --password-file /etc/step-ca/password.txt --provisioner-password-file /etc/step-ca/password.txt
+sudo chown -R step:step /etc/step-ca
+sudo tee /etc/systemd/system/step-ca.service <<'EOF'
+[Unit]
+Description=step-ca ({{ ca.name }})
+After=network-online.target
+
+[Service]
+User=step
+Environment=STEPPATH=/etc/step-ca
+ExecStart=/usr/bin/step-ca /etc/step-ca/config/ca.json --password-file /etc/step-ca/password.txt
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+sudo systemctl daemon-reload
+sudo systemctl enable --now step-ca
+sudo STEPPATH=/etc/step-ca step certificate fingerprint /etc/step-ca/certs/root_ca.crt
 ```
 
-> `step ca init` が表示する root 証明書のフィンガープリントを控えてください。以降の全ホストの登録に使います。
+> 最後に表示される root 証明書のフィンガープリントを控えてください。以降の全ホストの登録に使います。あわせて `sudo cat /etc/step-ca/password.txt` の値（provisioner パスワード。証明書発行時に必要）をパスワードマネージャ等の安全な場所に保管してください。
 
-## 2. 保護対象サービスの前段に mTLS 終端を置く
+## 2. サービスホストの共通準備（各ホストで 1 回）
 
-{% for s in services %}### {{ s.name }}（{{ s.host }} 上、upstream: {{ s.upstream }}）
+step CLI と Caddy を導入し、CA に登録します。Caddy は `trust_pool` ディレクティブ（2.8 以降）を使うため、ディストリのパッケージ（Ubuntu 24.04 は 2.6 系）ではなく公式リポジトリから導入します。
 
 ```bash
-sudo apt-get install -y caddy
+wget https://dl.smallstep.com/cli/docs-ca-install/latest/step-cli_amd64.deb
+sudo dpkg -i step-cli_amd64.deb
+sudo apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt-get update && sudo apt-get install -y caddy
 step ca bootstrap --ca-url https://{{ ca.host }}:8443 --fingerprint <控えたフィンガープリント>
-step ca certificate {{ s.fqdn }} /etc/caddy/{{ s.name }}.crt /etc/caddy/{{ s.name }}.key
-step ca root /etc/caddy/root_ca.crt
+step ca root root_ca.crt
+sudo install -m 644 root_ca.crt /etc/caddy/root_ca.crt
+```
+
+## 3. サーバ証明書を発行して mTLS 終端を置く
+
+{% for s in services %}{{ s.name }}（{{ s.host }} 上、upstream: {{ s.upstream }}）のサーバ証明書:
+
+```bash
+step ca certificate {{ s.fqdn }} {{ s.name }}.crt {{ s.name }}.key
+sudo install -m 644 {{ s.name }}.crt /etc/caddy/{{ s.name }}.crt
+sudo install -m 600 -o caddy -g caddy {{ s.name }}.key /etc/caddy/{{ s.name }}.key
+```
+
+{% endfor %}同一ホストの全サービスを 1 つの Caddyfile にまとめて書き込みます（ホストが分かれる場合は、そのホストに載るサービスのみ記載してください）。
+
+```bash
 sudo tee /etc/caddy/Caddyfile <<'EOF'
-{{ s.fqdn }}:443 {
+{% for s in services %}{{ s.fqdn }}:443 {
+  log
   tls /etc/caddy/{{ s.name }}.crt /etc/caddy/{{ s.name }}.key {
     client_auth {
       mode require_and_verify
@@ -39,13 +83,74 @@ sudo tee /etc/caddy/Caddyfile <<'EOF'
   }
   reverse_proxy {{ s.upstream }}
 }
-EOF
+{% endfor %}EOF
 sudo systemctl reload caddy
 ```
 
-upstream（{{ s.upstream }}）はループバック待ち受けに戻し、直接アクセスを閉じます。
+## 4. 平文の直接アクセス経路を閉じる
 
-{% endfor %}## 3. ファイアウォールを default deny にする
+mTLS ゲートウェイ経由以外の経路が残るとゼロトラストは成立しません。既存の待ち受けとファイアウォール許可を明示的に閉じます。以下は dgx-spark-ollama テンプレートで公開した ollama API（0.0.0.0 待ち受け + クライアント別 ufw 許可）を閉じる例です。
+
+```bash
+sudo sed -i 's|^Environment="OLLAMA_HOST=.*|Environment="OLLAMA_HOST=127.0.0.1:11434"|' /etc/systemd/system/ollama.service.d/override.conf
+sudo systemctl daemon-reload
+sudo systemctl restart ollama
+sudo ufw status numbered   # 11434 の allow ルール番号を確認
+sudo ufw delete allow from 192.168.10.21 to any port 11434 proto tcp
+sudo ufw delete allow from 192.168.10.31 to any port 11434 proto tcp
+```
+
+## 5. クライアント証明書を発行する
+
+利用者・端末ごとに短命の証明書を発行します。失効は期限切れ任せにせず `step ca revoke` で行えます。
+
+```bash
+{% for c in clients %}step ca certificate "{{ c.user }}@{{ c.device }}" {{ c.device }}.crt {{ c.device }}.key --not-after {{ c.cert_validity }}
+{% endfor %}```
+
+## 6. SSH を証明書認証に置き換える
+
+サーバ側で CA を信頼させ、証明書でのログインを確認してから、パスワード認証と静的鍵を無効化します。**この順序を守らないとロックアウトします。**
+
+サーバ側（各サービスホスト）で CA を信頼させます:
+
+```bash
+step ssh config --roots | sudo tee /etc/ssh/user_ca_keys.pub
+printf 'TrustedUserCAKeys /etc/ssh/user_ca_keys.pub\n' | sudo tee /etc/ssh/sshd_config.d/60-step-ca.conf
+sudo systemctl reload ssh
+```
+
+クライアント側で利用者ごとに SSH 証明書を発行します（有効期限 {{ ssh.user_cert_validity }}）:
+
+```bash
+{% for c in clients %}step ssh certificate --principal {{ ssh.principal }} --not-after {{ ssh.user_cert_validity }} {{ c.user }}@{{ site }} ~/.ssh/{{ c.user }}_step
+{% endfor %}```
+
+証明書でログインできることを確認します。**この確認が取れるまで次のブロックを実行しないでください**:
+
+```bash
+{% for s in services %}ssh -i ~/.ssh/{{ clients[0].user }}_step {{ ssh.principal }}@{{ s.host }} hostname
+{% endfor %}```
+
+確認後、パスワード認証と静的鍵（authorized_keys）を無効化します:
+
+```bash
+printf 'PasswordAuthentication no\nAuthorizedKeysFile none\n' | sudo tee -a /etc/ssh/sshd_config.d/60-step-ca.conf
+sudo systemctl reload ssh
+```
+
+## 7. ブルートフォース対策と監査ログ
+
+```bash
+sudo apt-get install -y fail2ban
+sudo systemctl enable --now fail2ban
+```
+
+アクセスの監査証跡は journald に残ります。ゲートウェイは `journalctl -u caddy`（Caddyfile の `log` ディレクティブによるアクセスログ）、証明書の発行履歴は `journalctl -u step-ca` で確認できます。
+
+## 8. ファイアウォールを default deny にする
+
+各サービスホスト:
 
 ```bash
 sudo ufw default deny incoming
@@ -53,27 +158,28 @@ sudo ufw default deny incoming
 {% endfor %}sudo ufw --force enable
 ```
 
-## 4. クライアント証明書を発行する
-
-利用者・端末ごとに短命の証明書を発行します。失効は期限切れ任せにせず `step ca revoke` で行えます。
+CA ホスト（{{ ca.host }}）では、証明書の発行・更新用に 8443 も許可します:
 
 ```bash
-{% for c in clients %}step ca certificate "{{ c.user }}@{{ c.device }}" {{ c.device }}.crt {{ c.device }}.key --not-after {{ c.cert_days * 24 }}h
-{% endfor %}```
-
-## 5. SSH を証明書認証に置き換える
-
-```bash
-step ssh certificate --principal ops ops-key   # 有効期限 {{ ssh.user_cert_validity }}（CA 側 provisioner 設定）
-sudo sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
-sudo systemctl reload ssh
+sudo ufw default deny incoming
+{% for port in firewall.allow_tcp %}sudo ufw allow {{ port }}/tcp
+{% endfor %}sudo ufw allow 8443/tcp
+sudo ufw --force enable
 ```
 
-## 6. 検証
+## 9. 検証
 
-証明書なしのアクセスが**拒否される**こと、証明書ありが通ることの両方を確認します。
+証明書なしのアクセスが**拒否される**こと、証明書ありが通ること、平文の直接経路が閉じていることをすべて確認します。
+
+各サービスの拒否確認:
 
 ```bash
-curl https://{{ services[0].fqdn }}/api/version --cacert root_ca.crt   # 失敗すること（クライアント証明書なし）
+{% for s in services %}curl https://{{ s.fqdn }}/api/version --cacert root_ca.crt   # 失敗すること（クライアント証明書なし）
+curl --max-time 3 http://{{ s.host }}:11434/api/version   # 失敗すること（セクション4で閉じた平文経路）
+{% endfor %}```
+
+各クライアントの許可確認:
+
+```bash
 {% for c in clients %}curl https://{{ services[0].fqdn }}/api/version --cacert root_ca.crt --cert {{ c.device }}.crt --key {{ c.device }}.key   # {{ c.user }}: 成功すること
 {% endfor %}```

--- a/assets/examples/zero-trust-access.yaml
+++ b/assets/examples/zero-trust-access.yaml
@@ -1,0 +1,23 @@
+site: ai-lab-tokyo
+ca:
+  host: step-ca-01
+  ip: 192.168.10.5
+  name: AI Lab Internal CA
+services:
+  - name: ollama-api
+    host: dgx-spark-01
+    upstream: 127.0.0.1:11434
+    fqdn: llm.ai-lab.internal
+clients:
+  - user: sato-taro
+    device: laptop-0042
+    cert_days: 30
+  - user: app-batch
+    device: app-server-01
+    cert_days: 7
+ssh:
+  user_cert_validity: 8h
+firewall:
+  allow_tcp:
+    - 443
+    - 22

--- a/assets/examples/zero-trust-access.yaml
+++ b/assets/examples/zero-trust-access.yaml
@@ -7,6 +7,12 @@ services:
     host: dgx-spark-01
     upstream: 127.0.0.1:11434
     fqdn: llm.ai-lab.internal
+# dgx-spark-ollamaテンプレートで開けた平文経路のufw許可 (クライアントIP/ポートを合わせること)
+plaintext_allows:
+  - from: 192.168.10.21
+    port: 11434
+  - from: 192.168.10.31
+    port: 11434
 clients:
   - user: sato-taro
     device: laptop-0042

--- a/assets/examples/zero-trust-access.yaml
+++ b/assets/examples/zero-trust-access.yaml
@@ -1,7 +1,6 @@
 site: ai-lab-tokyo
 ca:
   host: step-ca-01
-  ip: 192.168.10.5
   name: AI Lab Internal CA
 services:
   - name: ollama-api
@@ -11,11 +10,12 @@ services:
 clients:
   - user: sato-taro
     device: laptop-0042
-    cert_days: 30
+    cert_validity: 720h
   - user: app-batch
     device: app-server-01
-    cert_days: 7
+    cert_validity: 168h
 ssh:
+  principal: ops
   user_cert_validity: 8h
 firewall:
   allow_tcp:

--- a/docs/superpowers/specs/2026-07-02-ai-infra-templates-design.md
+++ b/docs/superpowers/specs/2026-07-02-ai-infra-templates-design.md
@@ -31,11 +31,13 @@ AskUserQuestion がインフラエラーで応答不能だったため、以下�
 既存の慣例（`<id>.<format>` + `<id>.j2` のペア、kebab-case id）に従う。
 
 - `dgx-spark-ollama.yaml` / `dgx-spark-ollama.j2`
-  - データ: ホスト名・タイムゾーン・LANサブネット・SSH方針・ollama設定（bind/port/keep_alive・モデル一覧）・接続クライアント
-  - 手順書: DGX OS初期設定（ホスト名/TZ/apt更新）→ SSH堅牢化 → ufw（default deny + LAN限定許可）→ ollamaインストール → systemdオーバーライドでLAN公開 → モデルpull → GPU/API動作確認
+  - データ: ホスト名・タイムゾーン・LANサブネット・SSH方針・ollama設定（port/keep_alive・モデル一覧）・接続クライアント（APIを許可する端末のIP）
+  - 手順書: DGX OS初期設定（ホスト名/TZ/apt更新）→ SSH堅牢化 → ufw（default deny + SSHはLAN、APIは許可クライアントIP単位）→ ollamaインストール → systemdオーバーライド+再起動でLAN公開 → モデルpull → GPU/API動作確認
 - `zero-trust-access.yaml` / `zero-trust-access.j2`
-  - データ: サイト名・CA情報・保護対象サービス（例: ollama API）・クライアント（人/端末）・SSH証明書ポリシー・許可ポート
-  - 手順書: ゼロトラスト方針の宣言（default deny・場所でなく証明書で認証・短命クレデンシャル）→ step-ca 初期化 → Caddy で mTLS 終端しupstreamへ → クライアント証明書発行（端末ごと）→ SSH証明書化（パスワード/静的鍵の無効化）→ fail2ban・監査ログ → 検証（証明書なしアクセスが拒否されること）
+  - データ: サイト名・CA情報・保護対象サービス（例: ollama API）・クライアント（端末ごとの証明書有効期限）・SSH証明書ポリシー・許可ポート。エンジンは常時 autoescape=True のため、シェルのクォートや `&` を含むコマンドはデータではなくテンプレート本文に置く（平文経路の閉鎖コマンドはこの制約により本文リテラル）
+  - 手順書: ゼロトラスト方針の宣言（default deny・場所でなく証明書で認証・短命クレデンシャル）→ CA構築（systemd常駐・パスワードファイル）→ 各サービスホスト共通準備（step CLI導入、公式リポジトリからCaddy 2.8+導入、CA登録）→ サーバ証明書発行とmTLS終端（ホスト単位でCaddyfile集約）→ 平文直接経路の閉鎖 → クライアント証明書発行（--not-after で短命化）→ SSH証明書化（TrustedUserCAKeys設定 → 証明書ログイン確認 → パスワード/静的鍵の無効化、の順でロックアウト防止）→ fail2ban・監査ログ（journald）→ default denyファイアウォール（CAホストは発行用8443も許可）→ 検証（証明書なし拒否・証明書あり成功・平文経路閉鎖の3点）
+
+初回実装に対する /code-review（8角度・全件検証）で、生成手順書の運用バグ10件（SSHロックアウト、mTLSゲートウェイ構築失敗、平文経路残存等）が確定し、上記はその修正を織り込んだ最終形である。
 
 ### 2. Web UI 登録
 

--- a/docs/superpowers/specs/2026-07-02-ai-infra-templates-design.md
+++ b/docs/superpowers/specs/2026-07-02-ai-infra-templates-design.md
@@ -1,0 +1,64 @@
+# 設計: AIインフラ特化テンプレートの追加[DGX Spark + ollama / ゼロトラストアクセス基盤]
+
+- Issue: #494
+- ブランチ: claude/ai-infrastructure-templates-9gzvkb
+- 日付: 2026-07-02
+
+## 背景と目的
+
+テンプレートライブラリの利用体験向上のため、今後需要が伸びるAIインフラに特化したテンプレート群を追加していく。本設計はその第1弾として次の2テンプレートを追加する。
+
+1. **DGX Spark + ollama を使ったAIマシンの初期セットアップ**
+2. **商用で使えるゼロトラストのセキュリティインフラ構築**（AIマシンのAPI/SSHへのアクセス基盤）
+
+いずれも Terraform / Ansible のような IaC が使えない現場を想定し、CLI手作業で完結する Markdown 手順書を生成する。
+
+## 確定した分岐[ブレインストーミング]
+
+AskUserQuestion がインフラエラーで応答不能だったため、以下は推奨案で自律確定した。オーナーレビューで差し戻し可能（テンプレート追加は可逆な変更）。
+
+| 分岐 | 確定 | 根拠 |
+| --- | --- | --- |
+| カテゴリ | **新カテゴリ `ai`（表示名: AIインフラ）を追加し、両テンプレートを配置** | オーナーは「AIインフラ特化テンプレートを今後も追加していく」と明言。系列の受け皿を先に用意する。ゼロトラストの題材もAIマシン保護に紐づけ、シリーズとして一貫させる |
+| ZTスタック | **OSSセルフホスト型: Caddy(Apache-2.0) + Smallstep step-ca(Apache-2.0) + nftables/ufw + fail2ban** | 「商用で使える」= 商用利用可能なライセンスかつベンダーロックインなし、と解釈。SaaS型（Cloudflare ZT等）はアカウント契約前提でIaC不使用現場の想定に反する。Authelia等のSSO統合は設定ファイルが重くCLI手順書の粒度を超えるため見送り（YAGNI） |
+| DGXスコープ | **基本セットアップのみ**: OS初期設定 + ollama導入 + モデルpull + LAN内API公開 + systemd常駐化 + 動作確認 | Open WebUI等のフロントは要望にないため見送り（YAGNI）。OS初期設定は linux-init と重複するが、DGX OS（Ubuntuベース）固有の文脈で自己完結させる |
+| データ形式 | **両方 YAML → Markdown 出力** | 手順書系の既存テンプレート（linux-init, incident-*）の慣例に従う |
+
+## 変更内容
+
+### 1. テンプレート実体（`assets/examples/`）
+
+既存の慣例（`<id>.<format>` + `<id>.j2` のペア、kebab-case id）に従う。
+
+- `dgx-spark-ollama.yaml` / `dgx-spark-ollama.j2`
+  - データ: ホスト名・タイムゾーン・LANサブネット・SSH方針・ollama設定（bind/port/keep_alive・モデル一覧）・接続クライアント
+  - 手順書: DGX OS初期設定（ホスト名/TZ/apt更新）→ SSH堅牢化 → ufw（default deny + LAN限定許可）→ ollamaインストール → systemdオーバーライドでLAN公開 → モデルpull → GPU/API動作確認
+- `zero-trust-access.yaml` / `zero-trust-access.j2`
+  - データ: サイト名・CA情報・保護対象サービス（例: ollama API）・クライアント（人/端末）・SSH証明書ポリシー・許可ポート
+  - 手順書: ゼロトラスト方針の宣言（default deny・場所でなく証明書で認証・短命クレデンシャル）→ step-ca 初期化 → Caddy で mTLS 終端しupstreamへ → クライアント証明書発行（端末ごと）→ SSH証明書化（パスワード/静的鍵の無効化）→ fail2ban・監査ログ → 検証（証明書なしアクセスが拒否されること）
+
+### 2. Web UI 登録
+
+- `web/src/lib/types.ts`: `TemplateCategory` に `"ai"` を追加
+- `web/src/components/Library.tsx`: `CATS` に `{ id: 'ai', label: 'AIインフラ', icon: 'terminal' }` を追加（既存アイコンを流用、新規SVGは作らない）
+- `web/src/lib/templates.ts`: META に2エントリ追加（`category: "ai"`, `format: "yaml"`, `output: "markdown"`, `live: true`, `updated: "2026-07-02"`）
+
+### 3. 変更しないもの
+
+- Pythonコア（`features/`）・レンダリングエンジン: 変更不要（テンプレートはデータとして読み込まれるのみ）
+- `web/src/lib/data.ts`（cisco-switchport専用のサンプル読込）: 対象外
+- README のユースケース例: テンプレートはライブラリUIから発見可能なため追記しない
+
+## エラーハンドリング
+
+`templates.ts` の `file()` はアセット欠落時に throw する既存ガードがあり、ペア漏れはビルド/テストで即検出される。追加のチェックは設けない。
+
+## 検証
+
+この環境で実行可能な検証（実行できないものはなし）:
+
+1. **本物のレンダリングエンジンでの描画確認**: `uv run python` で `features.config_parser.ConfigParser` + `features.document_render.DocumentRender` に新規2ペアを通し、strict undefined でエラーなく Markdown が生成されることを確認（Visual Debug 相当の検証）
+2. **型・単体テスト**: `cd web && npx tsc --noEmit && npm test`（`templates.ts` の glob 読込とUIスモークが通ること）
+3. **lint**: 既存のlint構成に従う
+
+E2E（render-parity）はテンプレート内容に依存しないため対象外。

--- a/web/src/components/Library.tsx
+++ b/web/src/components/Library.tsx
@@ -15,6 +15,7 @@ const CATS: { id: TemplateCategory | 'all'; label: string; icon: string }[] = [
   { id: 'server',  label: 'サーバ / Linux',  icon: 'server' },
   { id: 'dns',     label: 'DNS',            icon: 'ethernet-port' },
   { id: 'runbook', label: '手順書',          icon: 'config-file' },
+  { id: 'ai',      label: 'AIインフラ',       icon: 'terminal' },
 ];
 const FMT_TONE: Record<Format, 'brand' | 'info' | 'warning'> = { toml: 'brand', yaml: 'info', csv: 'warning' };
 const OUT_LABEL: Record<TemplateOutput, string> = { cli: 'CLI', config: 'config', markdown: 'Markdown' };

--- a/web/src/lib/templates.ts
+++ b/web/src/lib/templates.ts
@@ -32,6 +32,8 @@ const META: Meta[] = [
   { id: "incident-campus", name: "キャンパスネットワーク障害対応", desc: "症状・影響範囲・切り分けステップ・エスカレーションから Markdown 手順書を生成。", category: "runbook", format: "yaml", output: "markdown", updated: "2026-06-18", live: true },
   { id: "incident-proxy", name: "プロキシ環境のWebサービス接続不能", desc: "プロキシ設定・確認コマンド・判断分岐から Markdown 切り分け手順書を生成。", category: "runbook", format: "yaml", output: "markdown", updated: "2026-06-15", live: true },
   { id: "firewall-rules", name: "firewalld ルール一括投入", desc: "CSV の 1 行 1 ルールから、Rocky Linux 標準の firewalld rich rule 投入手順書（Markdown）を生成。", category: "network", format: "csv", output: "markdown", updated: "2026-06-30", live: true },
+  { id: "dgx-spark-ollama", name: "DGX Spark + ollama 初期構築", desc: "DGX OS の初期設定・SSH 堅牢化・ufw から、ollama の LAN 内 API 公開・モデル取得までの手順書（Markdown）を生成。", category: "ai", format: "yaml", output: "markdown", updated: "2026-07-02", live: true },
+  { id: "zero-trust-access", name: "ゼロトラストアクセス基盤構築", desc: "step-ca + Caddy の mTLS で AI マシンの API / SSH を保護する、商用利用可能な OSS 構成の構築手順書（Markdown）を生成。", category: "ai", format: "yaml", output: "markdown", updated: "2026-07-02", live: true },
 ];
 
 export const CGTemplates: Template[] = META.map((m) => ({

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,6 +1,6 @@
 import type { Format } from "./format";
 
-export type TemplateCategory = "network" | "server" | "dns" | "runbook";
+export type TemplateCategory = "network" | "server" | "dns" | "runbook" | "ai";
 export type TemplateOutput = "cli" | "config" | "markdown";
 
 export interface Template {


### PR DESCRIPTION
## Summary

Adds the first batch of the AI-infrastructure template series for IaC-less operations sites (refs #494):

- **DGX Spark + ollama initial setup** (`assets/examples/dgx-spark-ollama.{yaml,j2}`): DGX OS base setup, SSH hardening, default-deny ufw with per-client API allows, ollama install, LAN-scoped API exposure via systemd override + restart, model pulls, verification.
- **Zero-trust access infrastructure** (`assets/examples/zero-trust-access.{yaml,j2}`): commercially-licensed OSS stack only (step-ca / Caddy, both Apache-2.0). systemd-managed private CA, official-repo Caddy (>=2.8) mTLS termination, explicit closure of the plaintext API path, short-lived client certificates, SSH certificate auth with verify-before-lockout ordering, fail2ban + journald audit logs, default-deny firewall, deny/allow/plaintext-closed verification.
- New template category `ai` in the library UI (`web/src/lib/types.ts`, `web/src/lib/templates.ts`, `web/src/components/Library.tsx`).
- Design spec: `docs/superpowers/specs/2026-07-02-ai-infra-templates-design.md`.

## Review

A high-effort /code-review (8 finder angles, per-candidate verification) confirmed 10 operational-correctness findings in the initially generated runbooks (SSH lockout paths, non-working mTLS gateway, plaintext bypass, etc.). All 10 are fixed in the second commit; the spec was aligned to the shipped artifacts. One engine constraint surfaced and is documented in the spec: rendering uses autoescape=True, so data values must stay free of shell quoting characters (commands with quotes live in template literals).

## Verification

- Both data+template pairs re-rendered through the real Python engine (ConfigParser + DocumentRender, strict undefined) with per-finding assertions on the generated Markdown; no HTML entities in output.
- `tsc --noEmit` and vitest pass (39 tests; the pyodide-runtime node test cannot run in this sandbox because wheel vendoring is blocked with HTTP 403 - environment-only, expected to pass in CI).
- yamllint and whitespace hooks pass on the new files.

Refs #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01147fQXB3L2aG38M1zvgneD

---
_Generated by [Claude Code](https://claude.ai/code/session_01147fQXB3L2aG38M1zvgneD)_