### PR TITLE
ci(rulesets): protect main via ruleset sync + local apply harness (#503)

### DIFF
--- a/.github/rulesets/all-branches.json
+++ b/.github/rulesets/all-branches.json
@@ -4,7 +4,8 @@
         "ref_name": {
             "exclude": [
                 "~DEFAULT_BRANCH",
-                "refs/heads/dependabot/*"
+                "refs/heads/dependabot/*",
+                "refs/heads/chore/sync-*"
             ],
             "include": [
                 "~ALL"

--- a/.github/rulesets/all-branches.json
+++ b/.github/rulesets/all-branches.json
@@ -1,0 +1,22 @@
+{
+    "bypass_actors": [],
+    "conditions": {
+        "ref_name": {
+            "exclude": [
+                "~DEFAULT_BRANCH",
+                "refs/heads/dependabot/*"
+            ],
+            "include": [
+                "~ALL"
+            ]
+        }
+    },
+    "enforcement": "active",
+    "name": "all-branches-no-force-push",
+    "rules": [
+        {
+            "type": "non_fast_forward"
+        }
+    ],
+    "target": "branch"
+}

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,54 @@
+{
+    "bypass_actors": [],
+    "conditions": {
+        "ref_name": {
+            "exclude": [],
+            "include": [
+                "~DEFAULT_BRANCH"
+            ]
+        }
+    },
+    "enforcement": "active",
+    "name": "main-protection",
+    "rules": [
+        {
+            "type": "deletion"
+        },
+        {
+            "type": "non_fast_forward"
+        },
+        {
+            "type": "required_linear_history"
+        },
+        {
+            "type": "required_signatures"
+        },
+        {
+            "parameters": {
+                "allowed_merge_methods": [
+                    "merge",
+                    "squash",
+                    "rebase"
+                ],
+                "dismiss_stale_reviews_on_push": true,
+                "require_code_owner_review": false,
+                "require_last_push_approval": false,
+                "required_approving_review_count": 0,
+                "required_review_thread_resolution": true
+            },
+            "type": "pull_request"
+        },
+        {
+            "parameters": {
+                "required_status_checks": [
+                    {
+                        "context": "test-and-build / Workflow summary [Test & Build (on pull request)]"
+                    }
+                ],
+                "strict_required_status_checks_policy": true
+            },
+            "type": "required_status_checks"
+        }
+    ],
+    "target": "branch"
+}

--- a/.github/workflows/apply-rulesets.yml
+++ b/.github/workflows/apply-rulesets.yml
@@ -48,7 +48,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  GH_TOKEN: ${{ secrets.RULESETS_PAT }}
   REPO: ${{ github.repository }}
 
 jobs:
@@ -64,6 +63,8 @@ jobs:
           exit 1
 
       - name: Guard RULESETS_PAT
+        env:
+          GH_TOKEN: ${{ secrets.RULESETS_PAT }}
         run: |
           if [ -z "${GH_TOKEN}" ]; then
             echo "::error::RULESETS_PAT secret is not set. See docs/runbooks/rulesets.md \"Required secret\"."
@@ -105,6 +106,7 @@ jobs:
 
       - name: Plan and apply rulesets
         env:
+          GH_TOKEN: ${{ secrets.RULESETS_PAT }}
           MODE: ${{ inputs.dry_run && 'plan' || 'apply' }}
         run: |
           set -euo pipefail

--- a/.github/workflows/apply-rulesets.yml
+++ b/.github/workflows/apply-rulesets.yml
@@ -1,0 +1,114 @@
+# ============================================================
+# Workflow Information: apply-rulesets.yml
+# ============================================================
+#
+# 目的 (Purpose):
+# -----------------------------
+# `.github/rulesets/*.json` を正本として、GitHub Repository Rulesets API
+# (`GET/POST/PUT /repos/{repo}/rulesets`) へplan（差分表示のみ）またはapply
+# （実際に作成・更新）する。`tvna/claude-md`の`apply-rulesets.yml`の簡略版
+# （plan/applyの2モードのみ、auto-delete/workflow-permissionsサブコマンド
+# 無し、PATは1本のみ）。
+#
+# 影響範囲 (Scope of Impact):
+# ---------------------------
+# - `dry_run: false`でdispatchした場合のみ、リポジトリのruleset（main保護、
+#   全ブランチforce-push禁止）を実際に作成・更新する。
+# - `dry_run: true`（既定）では読み取りのみで、実際の変更は行わない。
+#
+# 必須シークレット (Required Secret):
+# -----------------------------------
+# - `RULESETS_PAT`: Administration: Read and write, Metadata: Read-only の
+#   fine-grained PAT。発行手順は docs/runbooks/rulesets.md を参照。
+#   `ruleset-apply` Environment に登録すること（Environment保護ルールで
+#   人間の承認を必須にできる）。
+#
+# 関連 (Reference):
+# -----------------
+# - Issue #503
+# - docs/runbooks/rulesets.md
+# ============================================================
+---
+name: Apply rulesets
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Plan only (diff + intent, no live changes)"
+        type: boolean
+        required: true
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  GH_TOKEN: ${{ secrets.RULESETS_PAT }}
+  REPO: ${{ github.repository }}
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: ruleset-apply
+    steps:
+      - name: Guard dispatch ref
+        if: github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop'
+        run: |
+          echo "::error::apply-rulesets must be dispatched against main or develop (got ${{ github.ref }})."
+          exit 1
+
+      - name: Guard RULESETS_PAT
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::RULESETS_PAT secret is not set. See docs/runbooks/rulesets.md \"Required secret\"."
+            exit 1
+          fi
+
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            release-assets.githubusercontent.com:443
+            files.pythonhosted.org:443
+            pypi.org:443
+            astral.sh:443
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Validate ruleset JSON syntax
+        run: |
+          set -euo pipefail
+          python3 -c "
+          import json
+          for f in ['.github/rulesets/main.json', '.github/rulesets/all-branches.json']:
+              json.load(open(f, encoding='utf-8'))
+              print(f'OK: {f}')
+          "
+
+      - name: Setup Python and restore cache
+        uses: ./.github/actions/setup-python
+        with:
+          python-version: ${{ vars.GLOBAL_PYTHON_VERSION }}
+
+      - name: Plan and apply rulesets
+        env:
+          MODE: ${{ inputs.dry_run && 'plan' || 'apply' }}
+        run: |
+          set -euo pipefail
+          python3 scripts/rulesets_apply.py "$MODE" \
+            --repo "${REPO}" \
+            --sot-dir .github/rulesets \
+            --summary-file "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-agent-instructions.yml
+++ b/.github/workflows/sync-agent-instructions.yml
@@ -4,12 +4,17 @@
 #
 # 目的 (Purpose):
 # ---------------
-# エージェント指示を上流から追従させる2つの独立したジョブを持つ。
+# エージェント指示を上流から追従させる3つの独立したジョブを持つ。
 #  - sync-claude-md: 正本リポジトリ tvna/claude-md の CLAUDE.md を取得し、
 #    本リポジトリの CLAUDE.md (コミット済み実ファイル) へ追従させる。
 #  - sync-apm-skills: apm.yml にピン留めした obra/superpowers /
 #    tvna/clairvoyance の上流コミットを検知し、pin 更新・再デプロイ・
 #    マニフェスト再生成を行う。
+#  - sync-rulesets: 正本リポジトリ tvna/claude-md の
+#    .github/rulesets/all-branches.json (全ブランチforce-push禁止、汎用的)
+#    のみを取得し、本リポジトリへ追従させる。main.json はcommand-ghostwriter
+#    固有のrequired_status_checksを含むローカル正本のため同期対象外
+#    (構造が変わった場合は人間が見て判断する)。
 # いずれも差分があれば PR を作成/更新する (レビュー必須・自動マージしない)。
 #
 # 方式の根拠 (Rationale):
@@ -34,6 +39,7 @@
 # 関連 (Reference):
 # -----------------
 # - Issue #427, #467 (CLAUDE.md 同期), #480 (apm スキル上流追従), #446 (apm バージョンアップ, 別スコープ)
+# - Issue #503 (main保護ruleset整備)
 # - 設計書 docs/superpowers/specs/2026-06-13-claude-md-master-sync-design.md
 # - 設計書 docs/superpowers/specs/2026-07-02-sync-apm-skills-upstream-update-design.md
 # ============================================================
@@ -208,3 +214,53 @@ jobs:
             Review required; do not auto-merge.
 
             Refs #480
+
+  sync-rulesets:
+    name: Sync all-branches ruleset from tvna/claude-md
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Check out this repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Check out upstream all-branches.json
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: tvna/claude-md
+          ref: main
+          sparse-checkout: .github/rulesets/all-branches.json
+          sparse-checkout-cone-mode: false
+          path: .upstream-claude-md
+
+      - name: Copy upstream all-branches.json into place
+        run: |
+          cp .upstream-claude-md/.github/rulesets/all-branches.json .github/rulesets/all-branches.json
+          rm -rf .upstream-claude-md
+
+      - name: Create or update pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sign-commits: true
+          base: main
+          branch: chore/sync-rulesets
+          delete-branch: true
+          commit-message: "chore: sync all-branches ruleset from tvna/claude-md (#503)"
+          title: "chore: sync all-branches ruleset from tvna/claude-md"
+          body: |
+            Automated sync of `.github/rulesets/all-branches.json` from the
+            master repository [`tvna/claude-md`](https://github.com/tvna/claude-md) (`main`).
+
+            `.github/rulesets/main.json` is intentionally NOT synced here: it
+            carries command-ghostwriter-specific `required_status_checks` and
+            is a local source of truth. Review required; do not auto-merge.
+
+            Refs #503

--- a/.github/workflows/sync-agent-instructions.yml
+++ b/.github/workflows/sync-agent-instructions.yml
@@ -12,9 +12,13 @@
 #    マニフェスト再生成を行う。
 #  - sync-rulesets: 正本リポジトリ tvna/claude-md の
 #    .github/rulesets/all-branches.json (全ブランチforce-push禁止、汎用的)
-#    のみを取得し、本リポジトリへ追従させる。main.json はcommand-ghostwriter
-#    固有のrequired_status_checksを含むローカル正本のため同期対象外
-#    (構造が変わった場合は人間が見て判断する)。
+#    のみを取得し、本リポジトリへ追従させる。取得後、command-ghostwriter
+#    固有のローカル追加 (refs/heads/chore/sync-* の除外——本ワークフロー自身の
+#    sync-*ジョブがPRブランチ更新のたびに強制更新するため、force-push禁止rule
+#    から除外する必要がある) を毎回自動で再適用する (#503)。人間の記憶に頼らず
+#    上流ドリフトで消えないようにするため、コピー後に決定的に付け直す。
+#    main.json はcommand-ghostwriter固有のrequired_status_checksを含む
+#    ローカル正本のため同期対象外 (構造が変わった場合は人間が見て判断する)。
 # いずれも差分があれば PR を作成/更新する (レビュー必須・自動マージしない)。
 #
 # 方式の根拠 (Rationale):
@@ -240,9 +244,29 @@ jobs:
           sparse-checkout-cone-mode: false
           path: .upstream-claude-md
 
-      - name: Copy upstream all-branches.json into place
+      - name: Copy upstream all-branches.json and reapply local exclude
         run: |
-          cp .upstream-claude-md/.github/rulesets/all-branches.json .github/rulesets/all-branches.json
+          set -euo pipefail
+          python3 -c "
+          import json
+
+          with open('.upstream-claude-md/.github/rulesets/all-branches.json', encoding='utf-8') as fp:
+              ruleset = json.load(fp)
+
+          # Local addition, not present upstream: command-ghostwriter's own
+          # sync-* jobs (this workflow) force-update their PR branch on every
+          # run via peter-evans/create-pull-request, which the upstream
+          # non_fast_forward rule would otherwise block. Re-apply it after
+          # every upstream copy so it survives drift (#503).
+          exclude = ruleset['conditions']['ref_name']['exclude']
+          pattern = 'refs/heads/chore/sync-*'
+          if pattern not in exclude:
+              exclude.append(pattern)
+
+          with open('.github/rulesets/all-branches.json', 'w', encoding='utf-8') as fp:
+              json.dump(ruleset, fp, indent=4, sort_keys=True)
+              fp.write('\n')
+          "
           rm -rf .upstream-claude-md
 
       - name: Create or update pull request
@@ -258,6 +282,12 @@ jobs:
           body: |
             Automated sync of `.github/rulesets/all-branches.json` from the
             master repository [`tvna/claude-md`](https://github.com/tvna/claude-md) (`main`).
+
+            The local exclude pattern `refs/heads/chore/sync-*` (needed so this
+            workflow's own sync-* PR branches aren't blocked by the force-push
+            ban) is re-applied automatically after copying from upstream; it
+            should be present in the diff below. If it is missing, the
+            re-apply step has a bug and this PR should not be merged as-is.
 
             `.github/rulesets/main.json` is intentionally NOT synced here: it
             carries command-ghostwriter-specific `required_status_checks` and

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
         language: system
         types: ["yaml"]
         files: ^\.github/
-        entry: bunx prettier --parser="yaml" ./.github --write
+        entry: bunx prettier --parser="yaml" --write
       - id: prettier-other-yaml
         name: prettier-other-yml
         description: Runs system-installed prettier to lint other yaml files

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -7,3 +7,4 @@
 
 - [開発者向けコマンド集](commands.md)
 - [Vercel デプロイ（アカウント作成から）](vercel-deploy.md)
+- [main保護ruleset（PAT発行からapply/verifyまで）](rulesets.md)

--- a/docs/runbooks/rulesets.md
+++ b/docs/runbooks/rulesets.md
@@ -16,8 +16,14 @@
 
 | ファイル | 対象 | 内容 |
 |---|---|---|
-| `.github/rulesets/all-branches.json` | デフォルトブランチと`dependabot/*`を除く全ブランチ | force-push禁止（`non_fast_forward`）のみ。`tvna/claude-md`から`sync-agent-instructions.yml`の`sync-rulesets`ジョブで自動追従（PR経由、自動マージなし）。 |
+| `.github/rulesets/all-branches.json` | デフォルトブランチ・`dependabot/*`・`chore/sync-*`を除く全ブランチ | force-push禁止（`non_fast_forward`）のみ。`tvna/claude-md`から`sync-agent-instructions.yml`の`sync-rulesets`ジョブで自動追従（PR経由、自動マージなし）。 |
 | `.github/rulesets/main.json` | デフォルトブランチ（`main`） | PR必須・force-push禁止・線形履歴・署名必須・必須ステータスチェック1件。**command-ghostwriter固有の`required_status_checks`を含むため上流と同期しないローカル正本。** |
+
+### `refs/heads/chore/sync-*`除外について（ローカル追加、上流との差分）
+
+`all-branches.json`の`exclude`には、上流`tvna/claude-md`には存在しない`refs/heads/chore/sync-*`が含まれる。理由: `sync-agent-instructions.yml`の`sync-claude-md`・`sync-apm-skills`・`sync-rulesets`各ジョブは`peter-evans/create-pull-request@v8.1.1`（`sign-commits: true`）を使ってPRブランチを作成・更新するが、既存PRが未マージのまま次回スケジュール実行を迎えると、同ブランチへの更新は必ずforce-push相当の操作（signed commitsの場合はGitHub APIの`updateRef(..., force: true)`）を行う。`non_fast_forward`ルールが適用された状態でこれが起きると、週次sync PRの更新が失敗する（Codexレビュー指摘、PR #504で発覚）。
+
+この除外は`sync-rulesets`ジョブが上流ファイルをコピーした**直後に、Pythonで決定的に再付与**する（レビュアーが手動で気付いて足し直す運用には頼らない）。ジョブが生成するPR本文にも「除外パターンが差分に含まれているはず」という自己点検の一文が入っている。万一再付与ロジックにバグがあり除外が消えた状態でPRが来たら、そのままマージしないこと。
 
 ## 1. 必須シークレット: `RULESETS_PAT`
 

--- a/docs/runbooks/rulesets.md
+++ b/docs/runbooks/rulesets.md
@@ -1,0 +1,87 @@
+# Runbook: main保護ruleset [PAT発行からapply/verifyまで]
+
+- 関連Issue: #503
+- 対象: `.github/rulesets/*.json`（正本） + `.github/workflows/apply-rulesets.yml`（適用ワークフロー）+ `scripts/rulesets_apply.py`（適用スクリプト）
+- 上流参照: `tvna/claude-md`の同名システムの簡略版。3PAT分割・週次ドリフト自動issue化・PR時同期gateは実装しない（YAGNI、[T6実行plan]参照）。
+
+## 0. 前提と全体像
+
+`.github/rulesets/*.json`がSoT（正本）。GitHubには自動適用されない——`apply-rulesets.yml`を`workflow_dispatch`で手動起動して初めてGitHub Repository Rulesets API (`GET/POST/PUT /repos/{repo}/rulesets`) へ反映される。
+
+```
+.github/rulesets/*.json を編集・コミット
+  -> Actions > Apply rulesets > Run workflow (dry_run=true) でplan確認
+  -> 意図通りならdry_run=falseで再dispatch -> 実際にGitHub側のrulesetを作成/更新
+```
+
+| ファイル | 対象 | 内容 |
+|---|---|---|
+| `.github/rulesets/all-branches.json` | デフォルトブランチと`dependabot/*`を除く全ブランチ | force-push禁止（`non_fast_forward`）のみ。`tvna/claude-md`から`sync-agent-instructions.yml`の`sync-rulesets`ジョブで自動追従（PR経由、自動マージなし）。 |
+| `.github/rulesets/main.json` | デフォルトブランチ（`main`） | PR必須・force-push禁止・線形履歴・署名必須・必須ステータスチェック1件。**command-ghostwriter固有の`required_status_checks`を含むため上流と同期しないローカル正本。** |
+
+## 1. 必須シークレット: `RULESETS_PAT`
+
+| 項目 | 値 |
+|---|---|
+| 種別 | Fine-grained personal access token |
+| Resource owner | `tvna` |
+| リポジトリアクセス | `tvna/command-ghostwriter`のみ |
+| リポジトリ権限 | **Administration: Read and write**（`/repos/{owner}/{repo}/rulesets`のGET/POST/PUTに必要）、**Metadata: Read-only**（fine-grained PATの必須付随権限） |
+| 有効期限 | 90日以内。ローテーション予定日をカレンダー等に記録すること。 |
+| 保存先 | `tvna/command-ghostwriter`リポジトリの`ruleset-apply` GitHub Environment secret |
+
+### 発行手順
+
+1. GitHubの自分のアカウント設定 > **Developer settings** を開く。
+2. **Personal access tokens** > **Fine-grained tokens** を開く。
+3. **Generate new token** を選ぶ。
+4. トークン名を`RULESETS_PAT`にする。
+5. 有効期限を90日以内に設定し、ローテーション予定日を控える。
+6. **Resource owner**で`tvna`を選ぶ。
+7. **Repository access**で**Only select repositories**を選び、`tvna/command-ghostwriter`のみを指定する。
+8. **Repository permissions**で以下を設定する:
+   - **Administration**: Read and write
+   - **Metadata**: Read-only
+9. トークンを生成し、一度だけ表示される値をコピーする。issue・PR・commit・ターミナル出力・このrunbookなど、いかなる場所にも値を貼り付けないこと。
+10. `tvna/command-ghostwriter` > **Settings** > **Environments** を開く。
+11. `ruleset-apply` Environmentを新規作成（無ければ）。
+12. Environment secretとして`RULESETS_PAT`に上記トークン値を登録する。
+13. `apply-rulesets.yml`を`dry_run=true`でdispatchし、guardステップが通り、実際の変更を伴わずplanがジョブサマリに出力されることを確認する（下記「疎通確認」参照）。
+
+### ローテーション
+
+有効期限が近づいたら、新しいPATを発行 → `ruleset-apply` Environmentの`RULESETS_PAT`を更新 → `dry_run=true`でdispatchしguardが通ることを確認 → 旧トークンを失効、の順で行う。ワークフロー側のコード変更は不要（`${{ secrets.RULESETS_PAT }}`を都度参照するため）。
+
+## 2. Apply（ワークフロー経由・唯一の適用経路）
+
+1. **Actions → Apply rulesets → Run workflow** を開く。
+2. `dry_run`を`true`（既定値）のまま実行する。
+3. ジョブサマリで各ファイルの action（`POST`=新規作成 / `PUT`=更新 / `ambiguous`=同名重複で中断）と、`PUT`の場合はlive側との差分（unified diff）を確認する。
+4. 差分が意図通りであれば、`dry_run=false`で再dispatchする。
+5. ジョブサマリの"Result id"列に返却されたruleset idを確認する（次回のPUTや手動ロールバックで必要）。
+
+`apply-rulesets.yml`は`main`または`develop`ブランチにdispatchされた場合のみ実行を許可する（`Guard dispatch ref`ステップ）。それ以外のブランチからのdispatchは`::error::`で拒否される。
+
+## 3. Verify
+
+適用後、GitHub UI上で以下を確認する:
+
+1. **Settings → Rules → Rulesets** で`main-protection`と`all-branches-no-force-push`が`enforcement: Active`で表示されること。
+2. `main`へ直接pushしようとすると拒否されること（PR経由のみ許可）。
+3. 任意のブランチへ`git push --force`すると拒否されること。
+4. `test-and-build / Workflow summary [Test & Build (on pull request)]`が失敗しているPRはマージボタンが無効化されること。
+5. docsのみを変更するPR（`test-and-build-on-pr.yml`の`paths-ignore`に該当）は、対になる`test-and-build-on-pr-skip.yml`が同名チェックを成功報告するため、正常にマージ可能なままであること（このペアリングが壊れると、docsのみのPRが永久にマージ不能になる——変更する際は要注意）。
+
+## 4. ロールバック
+
+ruleset削除はGitHub UIの**Settings → Rules → Rulesets**から対象rulesetを選び削除する（本リポジトリでは`enable_auto_delete`相当の自動削除機能は実装していない）。削除してもJSON正本はgitに残るため、`apply-rulesets.yml`を再dispatchすればPOST経路で同一内容を復元できる。
+
+緊急に一時的な保護解除が必要な場合（誤マージの取り消し等）は、`bypass_actors`を追加するのではなく、対象rulesetの`enforcement`を`"active"`から`"disabled"`へ変更するPRを作り、`apply-rulesets.yml`で適用し、対応後に`"active"`へ戻すPRを再度適用する手順を推奨する（監査ログに明示的な変更履歴を残すため）。
+
+## 5. スコープ外（将来の拡張候補）
+
+- 週次でlive rulesetとSoT JSONの差分を検知し自動でissueを起票するドリフト検出（上流`ruleset-drift`相当）。
+- PRオープン時にSoTの`required_status_checks`が実際のrulesetに反映済みか検証するgate（上流`verify-ruleset-sync`相当）。
+- apply用・verify用・dependabot用PATの3分割。
+
+これらはcommand-ghostwriterの規模（単一人間コントリビュータ、低頻度のruleset変更）に対して現時点では過剰と判断し、実装しない（[T6実行plan]参照）。将来コントリビュータが増える、またはruleset変更頻度が上がった場合に再検討する。

--- a/scripts/rulesets_apply.py
+++ b/scripts/rulesets_apply.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Plan and apply repository rulesets from checked-in source-of-truth JSON.
+
+Minimal port of tvna/claude-md's rulesets_apply.py: only the `plan`/`apply`
+subcommands against a single repo are kept (no auto-delete or workflow-
+permissions reconciliation, no multi-PAT split). Refs #503.
+
+Applying (not just planning) requires a token with Administration: Read and
+write on the target repository. See docs/runbooks/rulesets.md for how to
+issue that token.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+API_VERSION = "2022-11-28"
+API_ROOT = "https://api.github.com"
+PROJECTION_KEYS = ("name", "target", "enforcement", "conditions", "bypass_actors", "rules")
+SOT_FILES = ("all-branches.json", "main.json")
+
+
+class HTTPResponseLike(Protocol):
+    """Minimal shape of an HTTP response, matching both urlopen() and test doubles."""
+
+    status: int | None
+    code: int | None
+
+    def getcode(self) -> int | None: ...
+    def read(self) -> bytes: ...
+    def close(self) -> None: ...
+
+
+Opener = Callable[[urllib.request.Request], HTTPResponseLike]
+Sleeper = Callable[[float], None]
+
+
+def decide_action(sot_name: str, live: list[dict[str, Any]]) -> dict[str, Any]:
+    matches = [item for item in live if item.get("name") == sot_name]
+    if len(matches) == 0:
+        return {"action": "POST", "live_id": None, "match_count": 0}
+    if len(matches) == 1:
+        return {"action": "PUT", "live_id": matches[0].get("id"), "match_count": 1}
+    return {"action": "ambiguous", "live_id": None, "match_count": len(matches)}
+
+
+def canonical_projection(ruleset: dict[str, Any]) -> dict[str, Any]:
+    return {key: ruleset.get(key) for key in PROJECTION_KEYS}
+
+
+def render_diff_section(name: str, live_id: int, live: dict[str, Any], sot: dict[str, Any]) -> str:
+    live_text = _canonical_json_lines(canonical_projection(live))
+    sot_text = _canonical_json_lines(canonical_projection(sot))
+    diff = "".join(difflib.unified_diff(live_text, sot_text, fromfile="live", tofile="sot"))
+    return "\n".join(
+        [
+            "",
+            f"<details><summary>Diff for <code>{name}</code> (id {live_id})</summary>",
+            "",
+            "```diff",
+            diff,
+            "```",
+            "</details>",
+        ]
+    )
+
+
+def render_summary_row(file: str, name: str, matches: int, action: str, live_id: str | int | None) -> str:
+    result_id = "n/a" if live_id in (None, "") else str(live_id)
+    return f"| {file} | {name} | {matches} | {action} | {result_id} |"
+
+
+def fetch_live_rulesets(repo: str, token: str, *, opener: Opener = urllib.request.urlopen) -> list[dict[str, Any]]:
+    body = _request_json(f"{API_ROOT}/repos/{repo}/rulesets", token=token, opener=opener)
+    if not isinstance(body, list):
+        raise ValueError("GET /rulesets returned non-list JSON")
+    return body
+
+
+def fetch_live_ruleset(repo: str, ruleset_id: int, token: str, *, opener: Opener = urllib.request.urlopen) -> dict[str, Any]:
+    body = _request_json(f"{API_ROOT}/repos/{repo}/rulesets/{ruleset_id}", token=token, opener=opener)
+    if not isinstance(body, dict):
+        raise ValueError(f"ruleset {ruleset_id} returned non-object JSON")
+    return body
+
+
+def apply_call(
+    *,
+    method: str,
+    url: str,
+    payload_path: Path | None,
+    token: str,
+    opener: Opener = urllib.request.urlopen,
+    sleeper: Sleeper = time.sleep,
+) -> tuple[int, str]:
+    payload = payload_path.read_bytes() if payload_path is not None else None
+    final_code, final_body = 0, ""
+    for attempt in range(1, 4):
+        code, body = _request(url, token=token, method=method, data=payload, opener=opener)
+        final_code, final_body = code, body
+        if 200 <= code < 300:
+            return code, body
+        print(f"Attempt {attempt}: HTTP {_display_http_code(code)} for {method} {url}")
+        if code != 0 and code < 500:
+            return code, body
+        if attempt < 3:
+            sleeper(attempt * 5)
+    return final_code, final_body
+
+
+def render_dispatch_header(*, dry_run: bool) -> str:
+    return "\n".join(
+        [
+            "## Apply rulesets; dispatch summary",
+            "",
+            f"- dry_run: `{str(dry_run).lower()}`",
+            "",
+            "| File | Ruleset name | Matches | Action | Result id |",
+            "|---|---|---|---|---|",
+        ]
+    )
+
+
+def plan_rulesets(*, repo: str, sot_dir: Path, summary_file: Path, token: str, opener: Opener = urllib.request.urlopen) -> None:
+    live_rulesets = fetch_live_rulesets(repo, token, opener=opener)
+    rows: list[str] = [render_dispatch_header(dry_run=True)]
+    for file in SOT_FILES:
+        item, detail_rows = _plan_one_ruleset(
+            file=file, repo=repo, sot_dir=sot_dir, live_rulesets=live_rulesets, token=token, opener=opener, summary_file=summary_file
+        )
+        rows.extend(detail_rows)
+        rows.append(render_summary_row(file, str(item["name"]), int(item["matches"]), f"plan-only ({item['action']})", item["live_id"]))
+    _append_summary(summary_file, rows)
+
+
+def apply_rulesets(
+    *, repo: str, sot_dir: Path, summary_file: Path, token: str, opener: Opener = urllib.request.urlopen, sleeper: Sleeper = time.sleep
+) -> None:
+    live_rulesets = fetch_live_rulesets(repo, token, opener=opener)
+    _append_summary(summary_file, [render_dispatch_header(dry_run=False)])
+    for file in SOT_FILES:
+        item, detail_rows = _plan_one_ruleset(
+            file=file, repo=repo, sot_dir=sot_dir, live_rulesets=live_rulesets, token=token, opener=opener, summary_file=summary_file
+        )
+        if detail_rows:
+            _append_summary(summary_file, detail_rows)
+        action = str(item["action"])
+        url = f"{API_ROOT}/repos/{repo}/rulesets"
+        if action == "PUT":
+            url = f"{url}/{item['live_id']}"
+        code, body = apply_call(method=action, url=url, payload_path=item["path"], token=token, opener=opener, sleeper=sleeper)
+        if not 200 <= code < 300:
+            _append_summary(summary_file, ["", f"**Error applying {item['file']} (HTTP {_display_http_code(code)}):**", "```", body, "```"])
+            print(f"::error::Failed to {action} {item['file']} (last HTTP {_display_http_code(code)}).")
+            raise SystemExit(1)
+        response = json.loads(body or "{}")
+        _append_summary(
+            summary_file,
+            [render_summary_row(str(item["file"]), str(item["name"]), int(item["matches"]), f"{action} applied", response.get("id"))],
+        )
+
+
+def _plan_one_ruleset(
+    *, file: str, repo: str, sot_dir: Path, live_rulesets: list[dict[str, Any]], token: str, opener: Opener, summary_file: Path
+) -> tuple[dict[str, Any], list[str]]:
+    path = sot_dir / file
+    sot = _read_json_file(path)
+    name = str(sot["name"])
+    decision = decide_action(name, live_rulesets)
+    match_count = int(decision["match_count"])
+    action = str(decision["action"])
+    live_id = decision["live_id"]
+
+    if action == "ambiguous":
+        _append_summary(summary_file, [render_summary_row(file, name, match_count, "abort", None)])
+        print(f"::error::Multiple existing rulesets named '{name}' ({match_count}). Refusing to guess; resolve manually.")
+        raise SystemExit(1)
+
+    rows = []
+    if action == "PUT":
+        live = fetch_live_ruleset(repo, int(live_id), token, opener=opener)
+        rows.append(render_diff_section(name, int(live_id), live, sot))
+
+    return {"file": file, "path": path, "name": name, "matches": match_count, "action": action, "live_id": live_id}, rows
+
+
+def _canonical_json_lines(value: dict[str, Any]) -> list[str]:
+    text = json.dumps(value, indent=2, sort_keys=True) + "\n"
+    return text.splitlines(keepends=True)
+
+
+def _read_json_file(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as fp:
+        body = json.load(fp)
+    if not isinstance(body, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return body
+
+
+def _append_summary(path: Path, lines: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fp:
+        for line in lines:
+            fp.write(line)
+            fp.write("\n")
+
+
+def _request_json(url: str, *, token: str, opener: Opener = urllib.request.urlopen) -> object:
+    code, body = _request(url, token=token, method="GET", opener=opener)
+    if not 200 <= code < 300:
+        raise RuntimeError(f"GET {url} failed (HTTP {_display_http_code(code)}): {body}")
+    return json.loads(body)
+
+
+def _request(url: str, *, token: str, method: str, data: bytes | None = None, opener: Opener = urllib.request.urlopen) -> tuple[int, str]:
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": API_VERSION,
+    }
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    # `url` is built from API_ROOT (https://api.github.com) + workflow-supplied
+    # repo and ruleset_id values; opener is injectable for tests but defaults
+    # to urllib.request.urlopen on the fixed https endpoint.
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)  # noqa: S310 -- fixed https endpoint
+    try:
+        response = opener(request)
+        return _response_status(response), _response_body(response)
+    except urllib.error.HTTPError as exc:
+        return int(exc.code), exc.read().decode("utf-8", errors="replace")
+    except urllib.error.URLError as exc:
+        return 0, str(exc.reason)
+
+
+def _response_status(response: HTTPResponseLike) -> int:
+    status = getattr(response, "status", None) or getattr(response, "code", None)
+    if status is None and hasattr(response, "getcode"):
+        status = response.getcode()
+    return 0 if status is None else int(status)
+
+
+def _response_body(response: HTTPResponseLike) -> str:
+    try:
+        data = response.read()
+    finally:
+        close = getattr(response, "close", None)
+        if close is not None:
+            close()
+    return data.decode("utf-8", errors="replace")
+
+
+def _display_http_code(code: int) -> str:
+    return "000" if code == 0 else str(code)
+
+
+def _env_token() -> str:
+    token = os.environ.get("GH_TOKEN")
+    if not token:
+        print('::error::RULESETS_PAT secret is not set. See docs/runbooks/rulesets.md "Required secret".')
+        raise SystemExit(1)
+    return token
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--repo", required=True)
+    common.add_argument("--sot-dir", required=True, type=Path)
+    common.add_argument("--summary-file", required=True, type=Path)
+
+    plan = sub.add_parser("plan", parents=[common])
+    plan.set_defaults(func=_cmd_plan)
+
+    apply_parser = sub.add_parser("apply", parents=[common])
+    apply_parser.set_defaults(func=_cmd_apply)
+
+    args = parser.parse_args(argv)
+    try:
+        args.func(args)
+    except ValueError as exc:
+        print(f"::error::{exc}")
+        return 1
+    except SystemExit as exc:
+        return int(exc.code or 0)
+    return 0
+
+
+def _cmd_plan(args: argparse.Namespace) -> None:
+    plan_rulesets(repo=args.repo, sot_dir=args.sot_dir, summary_file=args.summary_file, token=_env_token())
+
+
+def _cmd_apply(args: argparse.Namespace) -> None:
+    apply_rulesets(repo=args.repo, sot_dir=args.sot_dir, summary_file=args.summary_file, token=_env_token())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rulesets_apply.py
+++ b/scripts/rulesets_apply.py
@@ -80,7 +80,10 @@ def render_summary_row(file: str, name: str, matches: int, action: str, live_id:
 
 
 def fetch_live_rulesets(repo: str, token: str, *, opener: Opener = urllib.request.urlopen) -> list[dict[str, Any]]:
-    body = _request_json(f"{API_ROOT}/repos/{repo}/rulesets", token=token, opener=opener)
+    # includes_parents=false: only repo-local rulesets, never an org-owned parent
+    # ruleset that happens to share a name. A parent ruleset's id lives under a
+    # different endpoint; matching one here would mis-route a PUT.
+    body = _request_json(f"{API_ROOT}/repos/{repo}/rulesets?includes_parents=false", token=token, opener=opener)
     if not isinstance(body, list):
         raise ValueError("GET /rulesets returned non-list JSON")
     return body

--- a/scripts/rulesets_apply.py
+++ b/scripts/rulesets_apply.py
@@ -82,7 +82,7 @@ def render_summary_row(file: str, name: str, matches: int, action: str, live_id:
 def fetch_live_rulesets(repo: str, token: str, *, opener: Opener = urllib.request.urlopen) -> list[dict[str, Any]]:
     # includes_parents=false: only repo-local rulesets, never an org-owned parent
     # ruleset that happens to share a name. A parent ruleset's id lives under a
-    # different endpoint; matching one here would mis-route a PUT.
+    # different endpoint; matching one here would send the PUT to the wrong place.
     body = _request_json(f"{API_ROOT}/repos/{repo}/rulesets?includes_parents=false", token=token, opener=opener)
     if not isinstance(body, list):
         raise ValueError("GET /rulesets returned non-list JSON")

--- a/tests/unit/test_rulesets_apply.py
+++ b/tests/unit/test_rulesets_apply.py
@@ -1,0 +1,187 @@
+"""Unit tests for scripts/rulesets_apply.py (repository ruleset plan/apply)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+    from urllib.request import Request
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "rulesets_apply.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("rulesets_apply", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeResponse:
+    def __init__(self, status: int, body: bytes) -> None:
+        self.status = status
+        self.code = status
+        self._body = body
+
+    def getcode(self) -> int:
+        return self.status
+
+    def read(self) -> bytes:
+        return self._body
+
+    def close(self) -> None:
+        pass
+
+
+class FakeOpener:
+    """Records requests and returns pre-scripted (status, body) pairs in order."""
+
+    def __init__(self, responses: list[tuple[int, dict[str, Any] | list[Any]]]) -> None:
+        self._responses = list(responses)
+        self.requests: list[Request] = []
+
+    def __call__(self, request: Request) -> FakeResponse:
+        self.requests.append(request)
+        status, payload = self._responses.pop(0)
+        return FakeResponse(status, json.dumps(payload).encode("utf-8"))
+
+
+@pytest.mark.unit
+def test_decide_action_no_match_returns_post() -> None:
+    mod = _load_module()
+    assert mod.decide_action("main-protection", []) == {"action": "POST", "live_id": None, "match_count": 0}
+
+
+@pytest.mark.unit
+def test_decide_action_one_match_returns_put() -> None:
+    mod = _load_module()
+    live = [{"name": "main-protection", "id": 42}]
+    assert mod.decide_action("main-protection", live) == {"action": "PUT", "live_id": 42, "match_count": 1}
+
+
+@pytest.mark.unit
+def test_decide_action_multiple_matches_returns_ambiguous() -> None:
+    mod = _load_module()
+    live = [{"name": "main-protection", "id": 1}, {"name": "main-protection", "id": 2}]
+    result = mod.decide_action("main-protection", live)
+    assert result["action"] == "ambiguous"
+    assert result["match_count"] == 2
+
+
+@pytest.mark.unit
+def test_canonical_projection_extracts_only_governed_keys() -> None:
+    mod = _load_module()
+    ruleset = {"id": 99, "name": "main-protection", "target": "branch", "created_at": "2026-01-01", "rules": [{"type": "deletion"}]}
+    projection = mod.canonical_projection(ruleset)
+    assert projection == {
+        "name": "main-protection",
+        "target": "branch",
+        "enforcement": None,
+        "conditions": None,
+        "bypass_actors": None,
+        "rules": [{"type": "deletion"}],
+    }
+
+
+@pytest.mark.unit
+def test_render_summary_row_formats_table_row() -> None:
+    mod = _load_module()
+    row = mod.render_summary_row("main.json", "main-protection", 1, "PUT applied", 42)
+    assert row == "| main.json | main-protection | 1 | PUT applied | 42 |"
+    empty_row = mod.render_summary_row("main.json", "main-protection", 0, "plan-only (POST)", None)
+    assert empty_row == "| main.json | main-protection | 0 | plan-only (POST) | n/a |"
+
+
+@pytest.mark.unit
+def test_plan_rulesets_posts_nothing_and_reports_post_for_new_ruleset(tmp_path: Path) -> None:
+    mod = _load_module()
+    sot_dir = REPO_ROOT / ".github" / "rulesets"
+    summary_file = tmp_path / "summary.md"
+
+    # Only one GET (list live rulesets) is expected for a pure plan; no live match.
+    opener = FakeOpener([(200, [])])
+
+    mod.plan_rulesets(repo="tvna/command-ghostwriter", sot_dir=sot_dir, summary_file=summary_file, token="fake-token", opener=opener)  # noqa: S106
+
+    assert len(opener.requests) == 1
+    assert opener.requests[0].get_method() == "GET"
+    summary = summary_file.read_text(encoding="utf-8")
+    assert "plan-only (POST)" in summary
+    assert "all-branches-no-force-push" in summary
+    assert "main-protection" in summary
+
+
+@pytest.mark.unit
+def test_apply_rulesets_creates_new_ruleset_via_post(tmp_path: Path) -> None:
+    mod = _load_module()
+    sot_dir = REPO_ROOT / ".github" / "rulesets"
+    summary_file = tmp_path / "summary.md"
+
+    # GET (list) once, then one POST per SoT file (all-branches.json, main.json).
+    opener = FakeOpener(
+        [
+            (200, []),
+            (201, {"id": 1001, "name": "all-branches-no-force-push"}),
+            (201, {"id": 1002, "name": "main-protection"}),
+        ]
+    )
+
+    mod.apply_rulesets(repo="tvna/command-ghostwriter", sot_dir=sot_dir, summary_file=summary_file, token="fake-token", opener=opener)  # noqa: S106
+
+    methods = [req.get_method() for req in opener.requests]
+    assert methods == ["GET", "POST", "POST"]
+    summary = summary_file.read_text(encoding="utf-8")
+    assert "POST applied" in summary
+
+
+@pytest.mark.unit
+def test_apply_rulesets_updates_existing_ruleset_via_put(tmp_path: Path) -> None:
+    mod = _load_module()
+    sot_dir = REPO_ROOT / ".github" / "rulesets"
+    summary_file = tmp_path / "summary.md"
+
+    live_main = {
+        "id": 2002,
+        "name": "main-protection",
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {},
+        "bypass_actors": [],
+        "rules": [],
+    }
+    live_all_branches = {
+        "id": 2001,
+        "name": "all-branches-no-force-push",
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {},
+        "bypass_actors": [],
+        "rules": [],
+    }
+    # GET (list, both already exist) -> GET (detail of all-branches for diff) -> PUT
+    # -> GET (detail of main for diff) -> PUT.
+    opener = FakeOpener(
+        [
+            (200, [{"id": 2001, "name": "all-branches-no-force-push"}, {"id": 2002, "name": "main-protection"}]),
+            (200, live_all_branches),
+            (200, {"id": 2001, "name": "all-branches-no-force-push"}),
+            (200, live_main),
+            (200, {"id": 2002, "name": "main-protection"}),
+        ]
+    )
+
+    mod.apply_rulesets(repo="tvna/command-ghostwriter", sot_dir=sot_dir, summary_file=summary_file, token="fake-token", opener=opener)  # noqa: S106
+
+    methods = [req.get_method() for req in opener.requests]
+    assert methods == ["GET", "GET", "PUT", "GET", "PUT"]
+    assert opener.requests[2].full_url.endswith("/rulesets/2001")
+    assert opener.requests[4].full_url.endswith("/rulesets/2002")


### PR DESCRIPTION
## 概要

「mainへ直接マージされないようworkflow整備」（T6）。ruleset SSoTは上流`tvna/claude-md`の`.github/rulesets`。command-ghostwriterの規模に合わせて最小構成に絞った簡略版を実装する。

- `.github/rulesets/all-branches.json`: 上流からそのまま追加（全ブランチforce-push禁止、デフォルトブランチと`dependabot/*`除く）。
- `.github/rulesets/main.json`: command-ghostwriter用にローカルで新規作成（PR必須・force-push禁止・線形履歴・署名必須・必須ステータスチェック1件）。上流の`required_status_checks`はclaude-md固有のCIジョブ名で転用不可のため、独自定義。
- `scripts/rulesets_apply.py` + `.github/workflows/apply-rulesets.yml`: GitHub Repository Rulesets APIへplan/apply（`workflow_dispatch`、`dry_run`既定true、`RULESETS_PAT`必須）する簡略版ハーネス。上流の3PAT分割・週次ドリフト自動issue化は実装しない（YAGNI）。
- `.github/workflows/sync-agent-instructions.yml`: `sync-rulesets`ジョブを追加し、`all-branches.json`のみを上流から自動追従（PR作成、レビュー必須、自動マージなし）。`main.json`はリポジトリ固有のため同期対象外。
- `docs/runbooks/rulesets.md`: PAT発行手順・apply/verify/rollback手順を新規ドキュメント化（CLAUDE.md 4章の秘密情報発行経路明記の要件に準拠）。

## 副次的な修正

`.pre-commit-config.yaml`の`prettier-github-actions-yaml`フックが`entry`に`./.github`ディレクトリを直書きしていたため、pre-commitが渡す`types: yaml`フィルタを無視してprettierが`.github/`配下の`.json`ファイルまで再帰的に拾い、`--parser=yaml`で不正なトレイリングカンマ入りJSONへ書き換えてしまう既存バグを本作業中に発見した。`entry`から`./.github`を削除し、pre-commitが渡すyamlファイルのみを対象にするよう修正した（新規ファイル追加まで顕在化しなかった既存の潜在バグ）。

## 重要な制約

**このPRのマージだけではmainは保護されません。** 実際に保護を有効化するには、オーナーが以下を実施する必要があります（このセッションはrepo admin権限を持たないため実行不可）:

1. `RULESETS_PAT`（Administration: Read and write, Metadata: Read-only、`tvna/command-ghostwriter`限定のfine-grained PAT）を発行し、`ruleset-apply` GitHub Environmentへ登録する（手順: `docs/runbooks/rulesets.md`）。
2. `apply-rulesets.yml`を`dry_run: false`で手動dispatchする。

## 検証

- `.github/rulesets/*.json`: `json.load()`で構文検証済み。
- `scripts/rulesets_apply.py`: `ruff check`/`ruff format`/`mypy`すべてクリーン。
- `tests/unit/test_rulesets_apply.py`: 8件のユニットテスト（`FakeOpener`でHTTP呼び出しをモック、実APIは叩かない）、全件pass。
- `.github/workflows/apply-rulesets.yml` / `sync-agent-instructions.yml`: yamllint pass。
- スコープ対象ファイル一式を`pre-commit run --files`で実行、全hook pass（exit 0、再実行しても差分なし＝冪等）。

## 別途対応（本PRのスコープ外）

- `workflow-summary`ジョブの`contains(needs.*.result, 'failure')`判定が、上流Guard系ジョブの失敗により`test-coverage`/`analysis-code-ccn`が`skipped`になったケースを検知できない潜在バグを発見。本PRでは修正せず、別issueで報告予定。

Refs #503


---
_Generated by [Claude Code](https://claude.ai/code/session_01BLHUMn5o8efGyJi49G7oxM)_