### PR TITLE
ci: create automated PRs with a GitHub App token (#511)

### DIFF
--- a/.github/workflows/sync-agent-instructions.yml
+++ b/.github/workflows/sync-agent-instructions.yml
@@ -16,13 +16,16 @@
 # -----------------------
 # - submodule + symlink は web 環境の fresh clone で壊れる (submodule は親clone
 #   に含まれない) ため、CLAUDE.md はコミット済み実ファイルとして同期する。
-# - CLAUDE.md 変更をトリガにする CI は無いため GITHUB_TOKEN のみで足りる (PAT 不要)。
-# - リポジトリ設定で "Allow GitHub Actions to create and approve pull requests"
-#   を有効化しておくこと。
+# - PR は GITHUB_TOKEN ではなく GitHub App トークン (actions/create-github-app-token)
+#   で作成する。GITHUB_TOKEN で作った PR は on: pull_request を発火させず必須CIが
+#   永久 pending となり `mergeable_state: blocked` に陥る (PR #510)。App トークンなら
+#   App bot 名義の Verified コミットとなり、下流 CI も発火する。上流 tvna/claude-md と
+#   同じ方式・同じ GitHub App を用いる (Issue #511)。
+# - secret `AUTOMATION_APP_ID` / `AUTOMATION_APP_PRIVATE_KEY` に上流と同じ App の
+#   App ID / PEM 秘密鍵を登録し、App を本リポジトリにインストールしておくこと
+#   (権限: Contents=write, Pull requests=write, Issues=write)。
 # - create-pull-request の sign-commits: true により、ローカル git commit ではなく
-#   GitHub API 経由でコミットを作成し、GITHUB_TOKEN のままで Verified 署名済みコミット
-#   とする (新規 GitHub App / secret は不要)。未設定だと署名必須ブランチ保護で
-#   PR が `mergeable_state: blocked` のままマージ不能になる (PR #464 で発生)。
+#   GitHub API 経由でコミットを作成し、App トークンで Verified 署名済みコミットとする。
 # - sync-apm-skills は上流の既定ブランチ最新コミットを REST API やフル checkout
 #   ではなく `git ls-remote <url> HEAD` で取得する (GitHub API のレート制限を回避)。
 # - apm.yml の2依存が同時に更新されていても PR は1本にまとめる
@@ -83,10 +86,17 @@ jobs:
           cp .upstream-claude-md/CLAUDE.md CLAUDE.md
           rm -rf .upstream-claude-md
 
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+
       - name: Create or update pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           sign-commits: true
           base: main
           branch: chore/sync-claude-md
@@ -189,11 +199,19 @@ jobs:
         if: steps.detect.outputs.changed == '1'
         run: python3 scripts/gen_superpowers_manifest.py
 
+      - name: Mint GitHub App token
+        id: app-token
+        if: steps.detect.outputs.changed == '1'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+
       - name: Create or update pull request
         if: steps.detect.outputs.changed == '1'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           sign-commits: true
           base: main
           branch: chore/sync-apm-skills

--- a/.github/workflows/test-and-build-on-push.yml
+++ b/.github/workflows/test-and-build-on-push.yml
@@ -321,6 +321,23 @@ jobs:
           echo "Ensure Labels Success: ${{ steps.ensure-labels.outputs.success }}"
           echo "Show commit log: $(cat .commit-log.txt)"
 
+      # PR は GITHUB_TOKEN ではなく GitHub App トークンで作成する。GITHUB_TOKEN で
+      # 作った PR は on: pull_request を発火させず必須CIが pending のまま blocked に
+      # 陥るため、App bot 名義で作成して下流 CI を発火させる。上流 tvna/claude-md と
+      # 同じ App を用いる (Issue #511)。
+      - name: Mint GitHub App token
+        id: app-token
+        if: |
+          steps.compare-versions.outputs.comparison-result == '>' &&
+          steps.check-pr.outputs.success == 'true' &&
+          steps.check-pr.outputs.pr_exists == 'false' &&
+          steps.check-pr.outputs.title_exists == 'false' &&
+          steps.ensure-labels.outputs.success == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+
       - name: Create Pull Request using github-script
         id: create-pr-script
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -331,7 +348,7 @@ jobs:
           steps.check-pr.outputs.title_exists == 'false' &&
           steps.ensure-labels.outputs.success == 'true'
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
             const developVersion = "${{ needs.get-develop-npm-version.outputs.version }}";

--- a/docs/superpowers/specs/2026-07-04-github-app-pr-token-design.md
+++ b/docs/superpowers/specs/2026-07-04-github-app-pr-token-design.md
@@ -1,0 +1,109 @@
+# Switch automated PR creation to a GitHub App token
+
+Refs #511. Upstream reference: `tvna/claude-md`.
+
+## Problem
+
+Automated PRs created with the default `GITHUB_TOKEN` (author
+`github-actions[bot]`) get stuck in `mergeable_state: blocked`
+(observed on PR #510, from the `sync-apm-skills` job).
+
+Two root causes:
+
+1. A PR created via `GITHUB_TOKEN` does not fire `on: pull_request`
+   events (GitHub's recursion guard). The required status checks defined
+   in `test-and-build-on-pr.yml` therefore never run, stay pending, and
+   the PR is blocked forever.
+2. The author/committer identity is the generic `github-actions[bot]`,
+   which does not line up cleanly with signed-commit branch protection.
+
+## Decision
+
+Mirror upstream `tvna/claude-md`: mint a short-lived GitHub App token
+with `actions/create-github-app-token` and use that token to author the
+PR. Use the **same GitHub App** as upstream. App-token PRs get a proper
+App-bot author, Verified commits, and DO trigger downstream CI, which
+clears the blocked state.
+
+## Scope
+
+Three PR-creating jobs across two workflows switch from `GITHUB_TOKEN`
+to an App token:
+
+| Workflow | Job | Mechanism | Change |
+| --- | --- | --- | --- |
+| `sync-agent-instructions.yml` | `sync-claude-md` | `peter-evans/create-pull-request` | mint App token; `token:` -> App token; keep `sign-commits: true` |
+| `sync-agent-instructions.yml` | `sync-apm-skills` | `peter-evans/create-pull-request` | same as above |
+| `test-and-build-on-push.yml` | `create-pr-to-main` | `github-script` `pulls.create` | mint App token; PR-creating step `github-token:` -> App token |
+
+Each job gains one step before its PR-creating step:
+
+```yaml
+- name: Mint GitHub App token
+  id: app-token
+  uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+  with:
+    app-id: ${{ secrets.AUTOMATION_APP_ID }}
+    private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+```
+
+The action version is pinned to the same SHA upstream uses (v3.2.0).
+
+`sign-commits: true` is retained on the peter-evans steps: with an App
+token, the commit is created through the GitHub API and shows Verified
+under the App identity.
+
+For `create-pr-to-main`, only the `create-pr-script` step (which calls
+`pulls.create` and adds labels to the new PR) switches to the App token,
+so the PR is authored by the App bot and triggers CI. The read-only
+`check-pr`, `ensure-labels`, and `set-status` steps stay on
+`GITHUB_TOKEN` (minimal change; no author sensitivity there).
+
+## Secrets (operator action, cannot be automated)
+
+New repo secrets holding the **same App** as upstream:
+
+- `AUTOMATION_APP_ID` - the GitHub App's numeric App ID.
+- `AUTOMATION_APP_PRIVATE_KEY` - the App's PEM private key.
+
+Issuance / handoff path:
+
+- Install the same GitHub App on `tvna/command-ghostwriter`.
+- Minimum App permissions: Contents = write, Pull requests = write,
+  Issues = write (labels).
+- Store the two values as repository (or org) Actions secrets. The PEM is
+  never echoed into logs; `create-github-app-token` masks the minted
+  token automatically.
+- Rotation: follows the App's private-key rotation; no extra cadence
+  introduced here.
+- Verification of handoff: run `Sync agent instructions` via
+  `workflow_dispatch`. The resulting PR must be authored by the App bot,
+  show Verified commits, and trigger the required PR CI. If the token
+  cannot be minted (missing/invalid secret), the job fails loudly at the
+  mint step rather than silently falling back.
+
+## Harden-runner
+
+`create-github-app-token` calls `api.github.com:443`. The
+`create-pr-to-main` job already allow-lists `api.github.com:443` and
+`github.com:443`. The `sync-agent-instructions.yml` jobs run
+`egress-policy: audit` (non-blocking), so no allow-list change is needed.
+
+## Non-goals
+
+- No change to the sync/release logic itself, only the token used to
+  author PRs.
+- No move away from `peter-evans/create-pull-request` to a GraphQL
+  `createCommitOnBranch` flow (upstream uses that for a different job;
+  keeping peter-evans is the smaller, equivalent-outcome change here).
+
+## Verification
+
+Static: `actionlint` / YAML parse on the two workflows (CI:
+`verify-superpowers.yml` and existing workflow linting).
+
+Behavioral (requires the secrets to exist, so it runs post-merge by the
+operator): `workflow_dispatch` of `Sync agent instructions` produces a
+PR authored by the App bot with Verified commits and triggered CI. This
+behavioral check cannot run in this environment because the secrets are
+not available here; that limitation is stated up front.


### PR DESCRIPTION
## Why

Automated PRs created with the default `GITHUB_TOKEN` (author `github-actions[bot]`) get stuck in `mergeable_state: blocked` (observed on #510, from the `sync-apm-skills` job).

Two root causes:
1. A PR created via `GITHUB_TOKEN` does not fire `on: pull_request` events (GitHub's recursion guard), so the required PR CI never runs, stays pending, and the PR is blocked forever.
2. The author/committer is the generic `github-actions[bot]`, which does not line up cleanly with signed-commit branch protection.

## What

Mirror upstream `tvna/claude-md`: mint a short-lived GitHub App token with `actions/create-github-app-token` (v3.2.0, same pinned SHA and same App as upstream) and use it to author the PR. App-token PRs get a proper App-bot author, Verified commits, and DO trigger downstream CI.

Three PR-creating jobs switch from `GITHUB_TOKEN` to the App token:

- `sync-agent-instructions.yml` -> `sync-claude-md` (peter-evans, `sign-commits: true` retained)
- `sync-agent-instructions.yml` -> `sync-apm-skills` (peter-evans, `sign-commits: true` retained)
- `test-and-build-on-push.yml` -> `create-pr-to-main` (github-script `pulls.create`)

Sync/release logic is unchanged; only the token used to author PRs changes.

## Operator action required before the next sync run (cannot be automated)

New repo secrets holding the **same App** as upstream:
- `AUTOMATION_APP_ID` - the App's numeric App ID
- `AUTOMATION_APP_PRIVATE_KEY` - the App's PEM private key

Steps:
- Install the same GitHub App on `tvna/command-ghostwriter` with permissions Contents=write, Pull requests=write, Issues=write.
- Add the two secrets (App ID and PEM key). The PEM is never echoed into logs; `create-github-app-token` masks the minted token automatically.
- Verify: run `Sync agent instructions` via `workflow_dispatch` and confirm the resulting PR is authored by the App bot, has Verified commits, and triggers the required PR CI.

If the secret is missing/invalid, the job fails loudly at the mint step (no silent fallback).

## Verification done here

- `actionlint 1.7.12`: no issues on both changed workflows.
- YAML parse: OK.
- Behavioral check (App-bot PR + Verified commit + CI trigger) requires the secrets, which are not available in this environment; it runs post-setup by the operator. Stated up front.

## Notes

- #510 itself is not fixed retroactively (created the old way). After this lands and the secrets exist, closing #510 and re-running the sync produces a proper App-bot PR.

Closes #511


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lmf3s99U3jTwMjFDEVUYdJ)_