### PR TITLE
ci: App-token + develop-target all 3 sync-agent-instructions jobs (#518)

### DIFF
--- a/.github/workflows/sync-agent-instructions.yml
+++ b/.github/workflows/sync-agent-instructions.yml
@@ -25,13 +25,25 @@
 # -----------------------
 # - submodule + symlink は web 環境の fresh clone で壊れる (submodule は親clone
 #   に含まれない) ため、CLAUDE.md はコミット済み実ファイルとして同期する。
-# - CLAUDE.md 変更をトリガにする CI は無いため GITHUB_TOKEN のみで足りる (PAT 不要)。
-# - リポジトリ設定で "Allow GitHub Actions to create and approve pull requests"
-#   を有効化しておくこと。
+# - PR は GITHUB_TOKEN ではなく GitHub App トークン (actions/create-github-app-token)
+#   で作成する。GITHUB_TOKEN で作った PR は on: pull_request を発火させず必須CIが
+#   永久 pending となり `mergeable_state: blocked` に陥る (PR #464, #510)。App トークン
+#   なら App bot 名義の Verified コミットとなり、下流 CI も発火する。上流
+#   tvna/claude-md と同じ方式・同じ GitHub App を用いる (Issue #511)。3ジョブ
+#   (sync-claude-md, sync-apm-skills, sync-rulesets) 全てが同じPR作成パターンを
+#   使うため、同じバグクラスを抱える。3ジョブとも同時にApp token化する。
+# - secret `AUTOMATION_APP_ID` / `AUTOMATION_APP_PRIVATE_KEY` に上流と同じ App の
+#   App ID / PEM 秘密鍵を登録し、App を本リポジトリにインストールしておくこと
+#   (権限: Contents=write, Pull requests=write, Issues=write)。
 # - create-pull-request の sign-commits: true により、ローカル git commit ではなく
-#   GitHub API 経由でコミットを作成し、GITHUB_TOKEN のままで Verified 署名済みコミット
-#   とする (新規 GitHub App / secret は不要)。未設定だと署名必須ブランチ保護で
-#   PR が `mergeable_state: blocked` のままマージ不能になる (PR #464 で発生)。
+#   GitHub API 経由でコミットを作成し、App トークンで Verified 署名済みコミットとする。
+# - PR は develop へ向ける (base: develop)。dependabot (4エコシステム全て
+#   target-branch: develop) や通常のfeature/fix PR (claude/* ブランチ) と揃え、
+#   develop で進行中の作業に指示・skill更新・ruleset更新を即座に反映するため。
+#   main は develop→main のバージョンゲート付きリリース昇格時にのみ追従する
+#   (Issue #518)。schedule/workflow_dispatch トリガーの既定checkoutは default
+#   branch (main) になるため、checkout に明示的な `ref: develop` が必須 (これが
+#   ないと diff/commit の基準ブランチが main のままずれる)。
 # - sync-apm-skills は上流の既定ブランチ最新コミットを REST API やフル checkout
 #   ではなく `git ls-remote <url> HEAD` で取得する (GitHub API のレート制限を回避)。
 # - apm.yml の2依存が同時に更新されていても PR は1本にまとめる
@@ -43,7 +55,7 @@
 # 関連 (Reference):
 # -----------------
 # - Issue #427, #467 (CLAUDE.md 同期), #480 (apm スキル上流追従), #446 (apm バージョンアップ, 別スコープ)
-# - Issue #503 (main保護ruleset整備)
+# - Issue #503 (main保護ruleset整備), #511 (App tokenへの移行), #518 (PR ターゲットを develop へ変更)
 # - 設計書 docs/superpowers/specs/2026-06-13-claude-md-master-sync-design.md
 # - 設計書 docs/superpowers/specs/2026-07-02-sync-apm-skills-upstream-update-design.md
 # ============================================================
@@ -78,6 +90,8 @@ jobs:
 
       - name: Check out this repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: develop
 
       - name: Check out master CLAUDE.md
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -93,12 +107,19 @@ jobs:
           cp .upstream-claude-md/CLAUDE.md CLAUDE.md
           rm -rf .upstream-claude-md
 
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+
       - name: Create or update pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           sign-commits: true
-          base: main
+          base: develop
           branch: chore/sync-claude-md
           delete-branch: true
           commit-message: "chore: sync CLAUDE.md from tvna/claude-md (#427)"
@@ -133,6 +154,8 @@ jobs:
 
       - name: Check out this repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: develop
 
       - name: Detect upstream apm dependency updates
         id: detect
@@ -199,13 +222,21 @@ jobs:
         if: steps.detect.outputs.changed == '1'
         run: python3 scripts/gen_superpowers_manifest.py
 
+      - name: Mint GitHub App token
+        id: app-token
+        if: steps.detect.outputs.changed == '1'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+
       - name: Create or update pull request
         if: steps.detect.outputs.changed == '1'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           sign-commits: true
-          base: main
+          base: develop
           branch: chore/sync-apm-skills
           delete-branch: true
           commit-message: "chore: sync apm skill dependency pins from upstream (#480)"
@@ -234,6 +265,8 @@ jobs:
 
       - name: Check out this repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: develop
 
       - name: Check out upstream all-branches.json
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -269,12 +302,19 @@ jobs:
           "
           rm -rf .upstream-claude-md
 
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+
       - name: Create or update pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           sign-commits: true
-          base: main
+          base: develop
           branch: chore/sync-rulesets
           delete-branch: true
           commit-message: "chore: sync all-branches ruleset from tvna/claude-md (#503)"


### PR DESCRIPTION
## Why

Redo of #519 (closed without merging). That PR was built from `main`'s copy of `sync-agent-instructions.yml` and incorrectly targeted `main` as its own PR base — `claude/*` branches in this repo are supposed to target `develop` (matches #504, #502, #497, #495, etc.).

Investigating further: `develop`'s actual copy of this file had diverged more than expected:
- It carries a **third job**, `sync-rulesets` (from #503/#504), that `main` never received.
- None of its three jobs had the GitHub App token fix from #511/#512 at all — still on `GITHUB_TOKEN`, same `mergeable_state: blocked` bug class as #510.

Owner decision (#518): apply the App-token fix to all three jobs at the same time as the `develop` retarget, rather than leaving `sync-rulesets` on the old broken pattern.

## What

This PR is built directly from `develop`'s current content (not `main`'s), so the diff is exactly, for all three jobs (`sync-claude-md`, `sync-apm-skills`, `sync-rulesets`):

- Add `actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1` (v3.2.0, same pinned SHA/App as upstream `tvna/claude-md`) minting, replacing `secrets.GITHUB_TOKEN`.
- Add explicit `ref: develop` to each job's initial checkout step. Without this, a `schedule`/`workflow_dispatch` trigger checks out the default branch (`main`) regardless of the PR's `base:`, leaving the diff/commit basis pointed at the wrong branch even after retargeting.
- `peter-evans/create-pull-request`'s `base: main` -> `base: develop` on all three jobs.
- Header comment updated with rationale and references to #511/#518.

`main` continues to receive these updates only via the existing version-gated `develop -> main` release-promotion job, per the owner's explicit decision recorded in #518.

## Requires (same secrets as #511/#512, not yet present on this repo)

- `AUTOMATION_APP_ID` / `AUTOMATION_APP_PRIVATE_KEY` repository secrets (same GitHub App as upstream). See #511/#512 for the full setup steps. If missing, the mint step fails loudly — no silent fallback.

## Verification done here

- `actionlint 1.7.12`: no issues.
- YAML parse: OK.
- Diffed directly against `origin/develop` to confirm the `sync-rulesets` job is preserved, not dropped, by this change.
- Behavioral verification (App-bot PR + Verified commit + CI trigger, for all three jobs) requires the next scheduled or manually dispatched run of `Sync agent instructions` on `develop`, post-merge.

Refs #511, #518, #503


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lmf3s99U3jTwMjFDEVUYdJ)_