### PR TITLE
ci: derive releases from develop titles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,14 @@ name: Release
 # Semantic versioning via semantic-release; the git tag is the single source of
 # truth. The full release flow and required setup live in docs/versioning.md.
 #
-# Cadence is intentional, not per-merge: a weekly schedule cuts the release, and
-# workflow_dispatch allows an ad-hoc release between weeks. Plain pushes to main
-# never release.
+# Cadence is intentional, not per-merge: a daily schedule cuts the release, and
+# workflow_dispatch allows an ad-hoc release between scheduled runs. Plain
+# pushes to main never release.
 
 on:
   schedule:
-    # Mondays at 01:17 UTC (~10:17 JST). Off-minute by GitHub's own guidance.
-    - cron: "17 1 * * 1"
+    # Daily at 21:00 UTC (06:00 JST). Off-hour to avoid the top-of-hour surge.
+    - cron: "0 21 * * *"
   workflow_dispatch:
 
 permissions:
@@ -54,6 +54,11 @@ jobs:
             echo "::error::No v-prefixed semver tag found. Seed the 0.x baseline first: git tag v0.3.6 && git push origin v0.3.6; refusing to risk silently releasing 1.0.0"
             exit 1
           fi
+
+      - name: Prepare release commits from develop
+        run: |
+          git fetch origin develop:refs/remotes/origin/develop --tags
+          node scripts/prepare_release_commits.mjs origin/develop
 
       - name: Run semantic-release
         env:

--- a/docs/superpowers/plans/2026-07-05-release-develop-merge-title-versioning.md
+++ b/docs/superpowers/plans/2026-07-05-release-develop-merge-title-versioning.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make the scheduled Release workflow run at 06:00 JST and derive semantic-release version bumps from release-worthy merge titles on `develop` while publishing from `main`.
 
-**Architecture:** Keep semantic-release as the release engine on `main`. Add a focused Node script that inspects `origin/develop` since the latest `vX.Y.Z` tag, creates local synthetic Conventional Commit inputs on top of the checked-out `main`, and lets the existing semantic-release plugins compute and publish the release.
+**Architecture:** Keep semantic-release as the release engine on `main`. Add a focused Node script that inspects `origin/develop`, skips source commits already recorded in the latest tagged release history, creates local synthetic Conventional Commit inputs on top of the checked-out `main`, and lets the existing semantic-release plugins compute and publish the release.
 
 **Tech Stack:** GitHub Actions YAML, Node.js ESM scripts using `node:child_process`, Python pytest workflow tests, existing semantic-release configuration.
 
@@ -13,7 +13,7 @@
 ## File Map
 
 - Create: `scripts/prepare_release_commits.mjs`
-  - Finds the latest release tag, extracts eligible `develop` merge titles, and creates local synthetic release-signal commits.
+  - Finds the latest release tag, extracts eligible `develop` titles, skips already released source SHAs, and creates local synthetic release-signal commits.
 - Modify: `tests/workflow/test_release_management.py`
   - Adds workflow assertions and temporary git repository tests for the script.
 - Modify: `.github/workflows/release.yml`
@@ -24,6 +24,7 @@
 ## Task 1: Workflow Contract Tests
 
 **Files:**
+
 - Modify: `tests/workflow/test_release_management.py`
 
 - [ ] **Step 1: Write the failing workflow test updates**
@@ -74,6 +75,7 @@ Do not commit yet. Task 1 is red-only and should be made green by Task 3.
 ## Task 2: Release Preparation Script Tests
 
 **Files:**
+
 - Modify: `tests/workflow/test_release_management.py`
 - Create: `scripts/prepare_release_commits.mjs`
 
@@ -211,6 +213,7 @@ Do not commit yet. Task 2 is red-only and should be made green by Task 3.
 ## Task 3: Implement Release Preparation
 
 **Files:**
+
 - Create: `scripts/prepare_release_commits.mjs`
 - Modify: `.github/workflows/release.yml`
 
@@ -252,9 +255,17 @@ function ensureRef(ref) {
 
 function latestReleaseTag() {
   try {
-    return git(["describe", "--tags", "--match", "v[0-9]*.[0-9]*.[0-9]*", "--abbrev=0"]);
+    return git([
+      "describe",
+      "--tags",
+      "--match",
+      "v[0-9]*.[0-9]*.[0-9]*",
+      "--abbrev=0",
+    ]);
   } catch {
-    fail("No v-prefixed semver tag found. Seed the release baseline before preparing release commits.");
+    fail(
+      "No v-prefixed semver tag found. Seed the release baseline before preparing release commits.",
+    );
   }
 }
 
@@ -274,23 +285,33 @@ function mergeTitlesSince(tag, ref) {
   if (!output) {
     return [];
   }
-  return output.split("\n").map((line) => line.trim()).filter(Boolean);
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
 }
 
 function createSyntheticCommit(subject) {
   const tree = git(["write-tree"]);
   const parent = git(["rev-parse", "HEAD"]);
-  const commit = execFileSync("git", ["commit-tree", tree, "-p", parent, "-m", subject], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  }).trim();
+  const commit = execFileSync(
+    "git",
+    ["commit-tree", tree, "-p", parent, "-m", subject],
+    {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  ).trim();
   git(["reset", "--soft", commit]);
 }
 
 ensureRef(developRef);
 const tag = latestReleaseTag();
 const titles = mergeTitlesSince(tag, developRef);
-const releaseTitles = titles.map(normalizeTitle).filter((title) => title !== null).reverse();
+const releaseTitles = titles
+  .map(normalizeTitle)
+  .filter((title) => title !== null)
+  .reverse();
 
 for (const title of releaseTitles) {
   createSyntheticCommit(title);
@@ -318,10 +339,10 @@ on:
 Add this step after `Require a baseline tag` and before `Run semantic-release`:
 
 ```yaml
-      - name: Prepare release commits from develop
-        run: |
-          git fetch origin develop:refs/remotes/origin/develop --tags
-          node scripts/prepare_release_commits.mjs origin/develop
+- name: Prepare release commits from develop
+  run: |
+    git fetch origin develop:refs/remotes/origin/develop --tags
+    node scripts/prepare_release_commits.mjs origin/develop
 ```
 
 - [ ] **Step 3: Run the focused workflow and script tests**
@@ -348,6 +369,7 @@ Expected: commit succeeds.
 ## Task 4: Documentation
 
 **Files:**
+
 - Modify: `docs/versioning.md`
 
 - [ ] **Step 1: Update release policy documentation**
@@ -360,11 +382,16 @@ Replace the "Automated Releases" section with:
 `.github/workflows/release.yml` runs semantic-release every day at 06:00 JST and
 via `workflow_dispatch`. Plain pushes to `main` do not publish releases.
 
-Release artifacts remain on `main`, but the release signal comes from merge
-titles that landed on `develop` since the latest `vX.Y.Z` tag. Before
-semantic-release runs, `scripts/prepare_release_commits.mjs` converts eligible
-`develop` merge titles into local Conventional Commit inputs on top of the
-checked-out `main` branch.
+Release artifacts remain on `main`, but the release signal comes from
+first-parent titles that landed on `develop`. Before semantic-release runs,
+`scripts/prepare_release_commits.mjs` reads the `develop` history, unwraps
+common GitHub merge commit bodies when needed, and creates local synthetic
+Conventional Commit inputs on top of the checked-out `main` branch.
+
+Each synthetic input records the source `develop` commit SHA with a
+`Release-Signal-Source:` marker. Later scheduled runs read those markers from
+the latest release tag and skip already released `develop` commits, so old
+titles do not trigger a new release every morning.
 
 The release uses Conventional Commits in merge titles:
 
@@ -404,6 +431,7 @@ Expected: commit succeeds.
 ## Task 5: Final Verification
 
 **Files:**
+
 - Read only unless failures require fixes.
 
 - [ ] **Step 1: Run the full workflow release-management test file**
@@ -439,3 +467,13 @@ Expected: only unrelated pre-existing untracked files remain, such as `.worktree
 - [ ] **Step 4: Summarize completion**
 
 Report the commit hashes, tests run, and any residual risk. Do not claim full release behavior was exercised unless semantic-release was actually run against a test repository.
+
+## Plan Drift Notes
+
+During Task 3 review, the implementation plan's initial `tag..develop` boundary
+was found to be insufficient because release tags are created on `main`, not on
+`develop`. The implemented script records each accepted source commit SHA in the
+synthetic commit body as `Release-Signal-Source: <sha>` and skips source SHAs
+already present in the latest tagged release history. The tests now cover this
+repeat-run case along with GitHub merge body unwrapping, squash/rebase-style
+subjects, and `BREAKING CHANGE` footers.

--- a/docs/superpowers/plans/2026-07-05-release-develop-merge-title-versioning.md
+++ b/docs/superpowers/plans/2026-07-05-release-develop-merge-title-versioning.md
@@ -1,0 +1,441 @@
+# Release Develop Merge Title Versioning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the scheduled Release workflow run at 06:00 JST and derive semantic-release version bumps from release-worthy merge titles on `develop` while publishing from `main`.
+
+**Architecture:** Keep semantic-release as the release engine on `main`. Add a focused Node script that inspects `origin/develop` since the latest `vX.Y.Z` tag, creates local synthetic Conventional Commit inputs on top of the checked-out `main`, and lets the existing semantic-release plugins compute and publish the release.
+
+**Tech Stack:** GitHub Actions YAML, Node.js ESM scripts using `node:child_process`, Python pytest workflow tests, existing semantic-release configuration.
+
+---
+
+## File Map
+
+- Create: `scripts/prepare_release_commits.mjs`
+  - Finds the latest release tag, extracts eligible `develop` merge titles, and creates local synthetic release-signal commits.
+- Modify: `tests/workflow/test_release_management.py`
+  - Adds workflow assertions and temporary git repository tests for the script.
+- Modify: `.github/workflows/release.yml`
+  - Changes the schedule to 06:00 JST and invokes the preparation script before semantic-release.
+- Modify: `docs/versioning.md`
+  - Documents the new source of release signals.
+
+## Task 1: Workflow Contract Tests
+
+**Files:**
+- Modify: `tests/workflow/test_release_management.py`
+
+- [ ] **Step 1: Write the failing workflow test updates**
+
+Update `test_release_workflow_runs_on_schedule_and_manual_dispatch_only`:
+
+```python
+def test_release_workflow_runs_on_schedule_and_manual_dispatch_only() -> None:
+    workflow = load_workflow()
+
+    assert workflow["name"] == "Release"
+    assert set(workflow[True]) == {"schedule", "workflow_dispatch"}
+    assert workflow[True]["schedule"] == [{"cron": "0 21 * * *"}]
+    assert "push" not in workflow[True]
+    assert "pull_request" not in workflow[True]
+```
+
+Add a new test after the baseline-tag test:
+
+```python
+def test_release_workflow_prepares_develop_merge_title_commits() -> None:
+    workflow = load_workflow()
+    steps = workflow["jobs"]["release"]["steps"]
+
+    prepare = next(step for step in steps if step["name"] == "Prepare release commits from develop")
+    assert "git fetch origin develop:refs/remotes/origin/develop --tags" in prepare["run"]
+    assert "node scripts/prepare_release_commits.mjs origin/develop" in prepare["run"]
+
+    run_release_index = next(index for index, step in enumerate(steps) if step["name"] == "Run semantic-release")
+    prepare_index = steps.index(prepare)
+    assert prepare_index < run_release_index
+```
+
+- [ ] **Step 2: Run the workflow tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/workflow/test_release_management.py::test_release_workflow_runs_on_schedule_and_manual_dispatch_only tests/workflow/test_release_management.py::test_release_workflow_prepares_develop_merge_title_commits -v
+```
+
+Expected: FAIL. The cron is still `17 1 * * 1`, and the preparation step does not exist.
+
+- [ ] **Step 3: Commit is deferred**
+
+Do not commit yet. Task 1 is red-only and should be made green by Task 3.
+
+## Task 2: Release Preparation Script Tests
+
+**Files:**
+- Modify: `tests/workflow/test_release_management.py`
+- Create: `scripts/prepare_release_commits.mjs`
+
+- [ ] **Step 1: Add test helpers**
+
+Add these imports near the top:
+
+```python
+import os
+```
+
+Add helper functions after `load_release_config`:
+
+```python
+def run_git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def commit_file(repo: Path, filename: str, content: str, message: str) -> None:
+    target = repo / filename
+    target.write_text(content, encoding="utf-8")
+    run_git(repo, "add", filename)
+    run_git(repo, "commit", "-m", message)
+
+
+def init_release_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run_git(repo, "init", "-b", "main")
+    run_git(repo, "config", "user.email", "release-test@example.com")
+    run_git(repo, "config", "user.name", "Release Test")
+    commit_file(repo, "README.md", "baseline\n", "chore: baseline")
+    run_git(repo, "tag", "v0.4.4")
+    run_git(repo, "checkout", "-b", "develop")
+    return repo
+
+
+def create_merge_commit(repo: Path, branch: str, filename: str, message: str) -> None:
+    run_git(repo, "checkout", "-b", branch, "main")
+    commit_file(repo, filename, f"{message}\n", message)
+    run_git(repo, "checkout", "develop")
+    run_git(repo, "merge", "--no-ff", branch, "-m", message)
+```
+
+- [ ] **Step 2: Add script behavior tests**
+
+Add these tests before `test_apply_version_updates_package_json_and_lockfile`:
+
+```python
+def test_prepare_release_commits_creates_conventional_inputs_from_develop_merges(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    assert node is not None
+    repo = init_release_repo(tmp_path)
+    create_merge_commit(repo, "feature-one", "feature.txt", "feat: add generated command preview")
+    create_merge_commit(repo, "bugfix-one", "bugfix.txt", "fix: preserve uploaded csv values")
+    main_head = run_git(repo, "rev-parse", "main").stdout.strip()
+    run_git(repo, "checkout", "main")
+
+    result = subprocess.run(
+        [node, str(ROOT / "scripts" / "prepare_release_commits.mjs"), "develop"],
+        check=False,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    subjects = run_git(repo, "log", "--format=%s", f"{main_head}..HEAD").stdout.splitlines()
+    assert subjects == [
+        "fix: preserve uploaded csv values",
+        "feat: add generated command preview",
+    ]
+    assert "accepted 2 release title(s)" in result.stdout
+
+
+def test_prepare_release_commits_ignores_non_release_titles(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    assert node is not None
+    repo = init_release_repo(tmp_path)
+    create_merge_commit(repo, "docs-only", "docs.txt", "docs: clarify release setup")
+    main_head = run_git(repo, "rev-parse", "main").stdout.strip()
+    run_git(repo, "checkout", "main")
+
+    result = subprocess.run(
+        [node, str(ROOT / "scripts" / "prepare_release_commits.mjs"), "develop"],
+        check=False,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert run_git(repo, "rev-parse", "HEAD").stdout.strip() == main_head
+    assert "accepted 0 release title(s)" in result.stdout
+
+
+def test_prepare_release_commits_fails_when_develop_ref_is_missing(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    assert node is not None
+    repo = init_release_repo(tmp_path)
+    run_git(repo, "checkout", "main")
+
+    result = subprocess.run(
+        [node, str(ROOT / "scripts" / "prepare_release_commits.mjs"), "origin/develop"],
+        check=False,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "develop ref not found: origin/develop" in result.stderr
+```
+
+- [ ] **Step 3: Run the script tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/workflow/test_release_management.py::test_prepare_release_commits_creates_conventional_inputs_from_develop_merges tests/workflow/test_release_management.py::test_prepare_release_commits_ignores_non_release_titles tests/workflow/test_release_management.py::test_prepare_release_commits_fails_when_develop_ref_is_missing -v
+```
+
+Expected: FAIL because `scripts/prepare_release_commits.mjs` does not exist.
+
+- [ ] **Step 4: Commit is deferred**
+
+Do not commit yet. Task 2 is red-only and should be made green by Task 3.
+
+## Task 3: Implement Release Preparation
+
+**Files:**
+- Create: `scripts/prepare_release_commits.mjs`
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Create the Node script**
+
+Create `scripts/prepare_release_commits.mjs`:
+
+```javascript
+import { execFileSync } from "node:child_process";
+
+const developRef = process.argv[2] ?? "origin/develop";
+
+function git(args, options = {}) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", options.stderr ?? "pipe"],
+  }).trim();
+}
+
+function gitQuiet(args) {
+  try {
+    git(args);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function ensureRef(ref) {
+  if (!gitQuiet(["rev-parse", "--verify", `${ref}^{commit}`])) {
+    fail(`develop ref not found: ${ref}`);
+  }
+}
+
+function latestReleaseTag() {
+  try {
+    return git(["describe", "--tags", "--match", "v[0-9]*.[0-9]*.[0-9]*", "--abbrev=0"]);
+  } catch {
+    fail("No v-prefixed semver tag found. Seed the release baseline before preparing release commits.");
+  }
+}
+
+function normalizeTitle(title) {
+  const trimmed = title.trim();
+  if (/^(feat|fix)(?:\([^)]+\))?!?: .+/.test(trimmed)) {
+    return trimmed;
+  }
+  if (/^.+!:.+/.test(trimmed)) {
+    return trimmed;
+  }
+  return null;
+}
+
+function mergeTitlesSince(tag, ref) {
+  const output = git(["log", "--merges", "--format=%s", `${tag}..${ref}`]);
+  if (!output) {
+    return [];
+  }
+  return output.split("\n").map((line) => line.trim()).filter(Boolean);
+}
+
+function createSyntheticCommit(subject) {
+  const tree = git(["write-tree"]);
+  const parent = git(["rev-parse", "HEAD"]);
+  const commit = execFileSync("git", ["commit-tree", tree, "-p", parent, "-m", subject], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+  git(["reset", "--soft", commit]);
+}
+
+ensureRef(developRef);
+const tag = latestReleaseTag();
+const titles = mergeTitlesSince(tag, developRef);
+const releaseTitles = titles.map(normalizeTitle).filter((title) => title !== null).reverse();
+
+for (const title of releaseTitles) {
+  createSyntheticCommit(title);
+}
+
+console.log(
+  `prepare-release-commits: accepted ${releaseTitles.length} release title(s), ignored ${
+    titles.length - releaseTitles.length
+  } title(s) from ${developRef} since ${tag}`,
+);
+```
+
+- [ ] **Step 2: Update the workflow**
+
+Modify `.github/workflows/release.yml`:
+
+```yaml
+on:
+  schedule:
+    # Daily at 21:00 UTC (06:00 JST). Off-hour to avoid the top-of-hour surge.
+    - cron: "0 21 * * *"
+  workflow_dispatch:
+```
+
+Add this step after `Require a baseline tag` and before `Run semantic-release`:
+
+```yaml
+      - name: Prepare release commits from develop
+        run: |
+          git fetch origin develop:refs/remotes/origin/develop --tags
+          node scripts/prepare_release_commits.mjs origin/develop
+```
+
+- [ ] **Step 3: Run the focused workflow and script tests**
+
+Run:
+
+```bash
+uv run pytest tests/workflow/test_release_management.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit the implementation**
+
+Run:
+
+```bash
+git add .github/workflows/release.yml scripts/prepare_release_commits.mjs tests/workflow/test_release_management.py
+git commit -m "ci: derive release commits from develop merge titles (#521)"
+```
+
+Expected: commit succeeds.
+
+## Task 4: Documentation
+
+**Files:**
+- Modify: `docs/versioning.md`
+
+- [ ] **Step 1: Update release policy documentation**
+
+Replace the "Automated Releases" section with:
+
+```markdown
+## Automated Releases
+
+`.github/workflows/release.yml` runs semantic-release every day at 06:00 JST and
+via `workflow_dispatch`. Plain pushes to `main` do not publish releases.
+
+Release artifacts remain on `main`, but the release signal comes from merge
+titles that landed on `develop` since the latest `vX.Y.Z` tag. Before
+semantic-release runs, `scripts/prepare_release_commits.mjs` converts eligible
+`develop` merge titles into local Conventional Commit inputs on top of the
+checked-out `main` branch.
+
+The release uses Conventional Commits in merge titles:
+
+- `fix:` creates a patch release.
+- `feat:` creates a minor release.
+- Breaking changes create a minor release while the project remains below
+  `1.0.0`.
+- Non-release titles such as `docs:` or `chore:` are ignored for version bump
+  purposes.
+
+When the project is ready for `1.0.0`, remove the breaking-change override from
+`.releaserc.json` so semantic-release can return to the default
+breaking-change-to-major behavior.
+```
+
+- [ ] **Step 2: Run the workflow tests again**
+
+Run:
+
+```bash
+uv run pytest tests/workflow/test_release_management.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit the docs**
+
+Run:
+
+```bash
+git add docs/versioning.md
+git commit -m "docs: explain develop merge title release signals (#521)"
+```
+
+Expected: commit succeeds.
+
+## Task 5: Final Verification
+
+**Files:**
+- Read only unless failures require fixes.
+
+- [ ] **Step 1: Run the full workflow release-management test file**
+
+Run:
+
+```bash
+uv run pytest tests/workflow/test_release_management.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run relevant lint if available**
+
+Run:
+
+```bash
+npx --yes prettier --check .github/workflows/release.yml scripts/prepare_release_commits.mjs package.json
+```
+
+Expected: PASS or report formatting that should be corrected before finalizing.
+
+- [ ] **Step 3: Inspect git status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only unrelated pre-existing untracked files remain, such as `.worktrees/`.
+
+- [ ] **Step 4: Summarize completion**
+
+Report the commit hashes, tests run, and any residual risk. Do not claim full release behavior was exercised unless semantic-release was actually run against a test repository.

--- a/docs/superpowers/specs/2026-07-05-release-develop-merge-title-versioning-design.md
+++ b/docs/superpowers/specs/2026-07-05-release-develop-merge-title-versioning-design.md
@@ -39,9 +39,10 @@ titles into a temporary commit range semantic-release can analyze.
 
 The workflow stays anchored on `main`. After checkout, it fetches the full
 `develop` history and tags. A preparation step finds the latest `vX.Y.Z` tag,
-reads merge commits reachable from `origin/develop` after that tag, extracts the
-merge titles, and creates release-signal commits on a temporary local branch.
-Those commits use Conventional Commit subjects, so the existing
+reads first-parent commits reachable from `origin/develop`, skips any source SHA
+already recorded in the latest tagged release history, extracts release-worthy
+titles, and creates release-signal commits on a temporary local branch. Those
+commits use Conventional Commit subjects, so the existing
 `@semantic-release/commit-analyzer` and release notes generator can compute the
 next version without replacing the release engine.
 
@@ -56,12 +57,18 @@ history and semantic-release's expected input.
 3. The workflow fetches `origin/develop` and tags.
 4. The baseline tag guard fails if no `v`-prefixed semver tag exists.
 5. The preparation script locates the latest release tag.
-6. The script reads merge commit subjects from `origin/develop` after that tag.
-7. Eligible titles are normalized into Conventional Commit subjects.
-8. The script creates local synthetic commits on top of `main`.
-9. semantic-release analyzes those local commits, computes the next version, and
-   runs the existing changelog, version update, git, and GitHub release plugins.
-10. Only semantic-release's normal release commit and tag are pushed to `main`.
+6. The script reads `Release-Signal-Source:` markers from the latest tagged
+   release history on `main`.
+7. The script reads first-parent messages from `origin/develop`, including merge
+   commit bodies and squash/rebase-style subjects.
+8. Already released source SHAs are skipped.
+9. Eligible titles are normalized into Conventional Commit subjects.
+10. The script creates local synthetic commits on top of `main`; each synthetic
+    commit records its source `develop` SHA with `Release-Signal-Source:`.
+11. semantic-release analyzes those local commits, computes the next version, and
+    runs the existing changelog, version update, git, and GitHub release plugins.
+12. Only semantic-release's normal release commit, its synthetic input ancestors,
+    and tag are pushed to `main`.
 
 ## Title Selection Rules
 
@@ -102,6 +109,7 @@ found, semantic-release should produce no release.
 - Outputs:
   - local synthetic Conventional Commit commits when release-worthy develop
     merge titles exist.
+  - a `Release-Signal-Source:` marker in each synthetic commit body.
   - no commits when no release-worthy titles exist.
 - Failure behavior:
   - fail loudly if `origin/develop` is missing.
@@ -113,7 +121,8 @@ Tests:
 - Workflow test asserts the 06:00 JST cron.
 - Workflow test asserts `develop` is fetched/prepared before semantic-release.
 - Script tests use a temporary git repository to cover patch, minor, breaking,
-  ignored title, and missing develop-ref behavior.
+  ignored title, GitHub merge body unwrapping, squash/rebase-style titles,
+  already released source skipping, and missing develop-ref behavior.
 - Existing `apply_version` tests remain unchanged.
 
 Docs:
@@ -135,12 +144,18 @@ Docs:
 - Risk: non-Conventional titles are silently ignored.
   Mitigation: the script prints a summary of accepted and ignored titles without
   exposing secrets.
+- Risk: a `main` release tag is not an ancestor of `develop`, so a plain
+  `tag..develop` range can include previously released `develop` commits again.
+  Mitigation: synthetic commits record `Release-Signal-Source:` markers and the
+  preparation step skips source SHAs already present in the latest tagged release
+  history.
 
 ## Acceptance Criteria
 
 - `Release` runs daily at 06:00 JST and remains manually dispatchable.
 - The workflow remains release-only: no push or pull request trigger.
-- The release job analyzes `develop` merge titles since the latest release tag.
+- The release job analyzes unreleased `develop` titles and skips source commits
+  already recorded in the latest tagged release history.
 - semantic-release still owns version calculation, changelog generation, package
   version updates, release commits, tags, and GitHub Releases.
 - Tests cover workflow schedule, develop preparation, and merge-title conversion

--- a/docs/superpowers/specs/2026-07-05-release-develop-merge-title-versioning-design.md
+++ b/docs/superpowers/specs/2026-07-05-release-develop-merge-title-versioning-design.md
@@ -1,0 +1,148 @@
+# Release Develop Merge Title Versioning Design
+
+## Context
+
+The repository already uses semantic-release from the `Release` workflow. The
+release tag is the source of truth, and semantic-release prepares
+`package.json`, `package-lock.json`, `CHANGELOG.md`, the git tag, and the
+GitHub Release from `main`.
+
+The missing behavior is the release signal. Routine development lands on
+`develop`, but the current release job only analyzes commits available to the
+semantic-release run on `main`. That leaves version selection dependent on
+manual version edits or on commit history that may not reflect the merge titles
+used for the development branch.
+
+Issue: #521.
+
+## Goals
+
+- Run the `Release` workflow automatically every day at 06:00 JST.
+- Keep releases, tags, changelog updates, and package version commits on `main`.
+- Derive the semantic-release bump signal from merge titles that landed on
+  `develop` since the previous `vX.Y.Z` release tag.
+- Preserve the existing baseline tag guard and semantic-release plugin flow.
+- Cover the workflow and release-signal preparation behavior with deterministic
+  tests.
+
+## Non-Goals
+
+- Do not move the release branch from `main` to `develop`.
+- Do not replace semantic-release with a custom release publisher.
+- Do not require GitHub API access for the first implementation.
+- Do not hand-edit package versions for routine releases.
+
+## Recommended Approach
+
+Add a small release-preparation script that converts eligible `develop` merge
+titles into a temporary commit range semantic-release can analyze.
+
+The workflow stays anchored on `main`. After checkout, it fetches the full
+`develop` history and tags. A preparation step finds the latest `vX.Y.Z` tag,
+reads merge commits reachable from `origin/develop` after that tag, extracts the
+merge titles, and creates release-signal commits on a temporary local branch.
+Those commits use Conventional Commit subjects, so the existing
+`@semantic-release/commit-analyzer` and release notes generator can compute the
+next version without replacing the release engine.
+
+This avoids depending on the GitHub API, keeps all published release artifacts on
+`main`, and limits new logic to one auditable bridge between `develop` merge
+history and semantic-release's expected input.
+
+## Data Flow
+
+1. `Release` starts by schedule or manual dispatch.
+2. The workflow checks out `main` with full history and the release token.
+3. The workflow fetches `origin/develop` and tags.
+4. The baseline tag guard fails if no `v`-prefixed semver tag exists.
+5. The preparation script locates the latest release tag.
+6. The script reads merge commit subjects from `origin/develop` after that tag.
+7. Eligible titles are normalized into Conventional Commit subjects.
+8. The script creates local synthetic commits on top of `main`.
+9. semantic-release analyzes those local commits, computes the next version, and
+   runs the existing changelog, version update, git, and GitHub release plugins.
+10. Only semantic-release's normal release commit and tag are pushed to `main`.
+
+## Title Selection Rules
+
+The first implementation should prefer explicit Conventional Commit titles:
+
+- `fix:` creates a patch release.
+- `feat:` creates a minor release.
+- titles with `!` or `BREAKING CHANGE` create a minor release while the project
+  remains below `1.0.0`, matching the current `.releaserc.json` rule.
+
+Common GitHub merge commit wrappers should be unwrapped when possible. For
+example, `Merge pull request #123 from owner/branch` can be paired with the next
+subject line if available in the merge commit body. Squash or rebase style
+commits that already use a Conventional Commit subject are accepted directly.
+
+Titles that do not map to a release type are ignored. If no eligible title is
+found, semantic-release should produce no release.
+
+## Workflow Changes
+
+`.github/workflows/release.yml` changes:
+
+- Schedule cron becomes `0 21 * * *`, which is 06:00 JST.
+- The comment should name both UTC and JST times.
+- Add a fetch/preparation step before `Run semantic-release`.
+- Keep `workflow_dispatch`.
+- Keep no `push` or `pull_request` release trigger.
+- Keep the baseline tag guard before release analysis.
+
+## Components
+
+`scripts/prepare_release_commits.mjs`:
+
+- Inputs:
+  - release branch HEAD from the current checkout.
+  - develop ref, defaulting to `origin/develop`.
+  - latest release tag discovered from local tags.
+- Outputs:
+  - local synthetic Conventional Commit commits when release-worthy develop
+    merge titles exist.
+  - no commits when no release-worthy titles exist.
+- Failure behavior:
+  - fail loudly if `origin/develop` is missing.
+  - fail loudly if no baseline tag is present.
+  - fail loudly if git commands fail.
+
+Tests:
+
+- Workflow test asserts the 06:00 JST cron.
+- Workflow test asserts `develop` is fetched/prepared before semantic-release.
+- Script tests use a temporary git repository to cover patch, minor, breaking,
+  ignored title, and missing develop-ref behavior.
+- Existing `apply_version` tests remain unchanged.
+
+Docs:
+
+- `docs/versioning.md` explains that release signals come from `develop` merge
+  titles while release artifacts remain on `main`.
+- The document includes examples of titles that produce patch, minor, and no
+  release.
+
+## Risks And Mitigations
+
+- Risk: merge commits may not contain the PR title in the subject.
+  Mitigation: inspect both subject and body lines and document the supported
+  merge styles.
+- Risk: synthetic commits might be pushed accidentally.
+  Mitigation: only semantic-release pushes its configured assets and tag; the
+  preparation commits are local inputs. Tests assert the workflow still invokes
+  semantic-release through the existing release step.
+- Risk: non-Conventional titles are silently ignored.
+  Mitigation: the script prints a summary of accepted and ignored titles without
+  exposing secrets.
+
+## Acceptance Criteria
+
+- `Release` runs daily at 06:00 JST and remains manually dispatchable.
+- The workflow remains release-only: no push or pull request trigger.
+- The release job analyzes `develop` merge titles since the latest release tag.
+- semantic-release still owns version calculation, changelog generation, package
+  version updates, release commits, tags, and GitHub Releases.
+- Tests cover workflow schedule, develop preparation, and merge-title conversion
+  behavior.
+- `docs/versioning.md` reflects the new release policy.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -15,21 +15,34 @@ The git tag is the source of truth for releases. `package.json` and
 `package-lock.json` are updated automatically during release preparation by
 `scripts/apply_version.mjs`, then committed with the generated `CHANGELOG.md`.
 
-Do not hand-edit the package version for routine releases. Land conventional
-commits on `main`; the release workflow computes the next version from the
-commits since the latest `vX.Y.Z` tag.
+Do not hand-edit the package version for routine releases. Land release-worthy
+titles on `develop`; the release workflow converts those titles into local
+semantic-release input commits while publishing the release from `main`.
 
 ## Automated Releases
 
-`.github/workflows/release.yml` runs semantic-release on a weekly schedule and
+`.github/workflows/release.yml` runs semantic-release every day at 06:00 JST and
 via `workflow_dispatch`. Plain pushes to `main` do not publish releases.
 
-The release uses Conventional Commits:
+Release artifacts remain on `main`, but the release signal comes from
+first-parent titles that landed on `develop`. Before semantic-release runs,
+`scripts/prepare_release_commits.mjs` reads the `develop` history, unwraps
+common GitHub merge commit bodies when needed, and creates local synthetic
+Conventional Commit inputs on top of the checked-out `main` branch.
+
+Each synthetic input records the source `develop` commit SHA with a
+`Release-Signal-Source:` marker. Later scheduled runs read those markers from
+the latest release tag and skip already released `develop` commits, so old
+titles do not trigger a new release every morning.
+
+The release uses Conventional Commit titles:
 
 - `fix:` creates a patch release.
 - `feat:` creates a minor release.
 - Breaking changes create a minor release while the project remains below
   `1.0.0`.
+- Non-release titles such as `docs:` or `chore:` are ignored for version bump
+  purposes.
 
 When the project is ready for `1.0.0`, remove the breaking-change override from
 `.releaserc.json` so semantic-release can return to the default

--- a/scripts/prepare_release_commits.mjs
+++ b/scripts/prepare_release_commits.mjs
@@ -1,0 +1,156 @@
+import { execFileSync } from "node:child_process";
+
+const developRef = process.argv[2] ?? "origin/develop";
+const conventionalSubjectPattern = /^[a-z][a-z0-9-]*(?:\([^)]+\))?!?: .+$/;
+const releaseSubjectPattern =
+  /^(?:(?:feat|fix)(?:\([^)]+\))?!?: .+|[a-z][a-z0-9-]*(?:\([^)]+\))?!: .+)$/;
+const breakingFooterPattern = /^BREAKING CHANGE(?:\([^)]+\))?: .+/m;
+const releaseSignalSourcePattern = /^Release-Signal-Source: ([0-9a-f]{40})$/gm;
+
+function git(args, options = {}) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", options.stderr ?? "pipe"],
+  }).trim();
+}
+
+function gitQuiet(args) {
+  try {
+    git(args);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function ensureRef(ref) {
+  if (!gitQuiet(["rev-parse", "--verify", `${ref}^{commit}`])) {
+    fail(`develop ref not found: ${ref}`);
+  }
+}
+
+function latestReleaseTag() {
+  try {
+    return git([
+      "describe",
+      "--tags",
+      "--match",
+      "v[0-9]*.[0-9]*.[0-9]*",
+      "--abbrev=0",
+    ]);
+  } catch {
+    fail(
+      "No v-prefixed semver tag found. Seed the release baseline before preparing release commits.",
+    );
+  }
+}
+
+function releaseEntryFromCommit(commit) {
+  const { sha, message } = commit;
+  const lines = message.split(/\r?\n/);
+  const firstSubject = lines[0]?.trim() ?? "";
+  const subjectIndex = releaseSubjectPattern.test(firstSubject)
+    ? 0
+    : lines.findIndex((line) => conventionalSubjectPattern.test(line.trim()));
+
+  if (subjectIndex === -1) {
+    return null;
+  }
+
+  const subject = lines[subjectIndex].trim();
+  const body = lines
+    .slice(subjectIndex + 1)
+    .join("\n")
+    .trim();
+
+  if (releaseSubjectPattern.test(subject) || breakingFooterPattern.test(body)) {
+    return { sourceSha: sha, subject, body };
+  }
+
+  return null;
+}
+
+function firstParentCommitsSince(tag, ref) {
+  const output = git([
+    "log",
+    "--first-parent",
+    "--format=%x1e%H%x1f%B",
+    `${tag}..${ref}`,
+  ]);
+  if (!output) {
+    return [];
+  }
+  return output
+    .split("\x1e")
+    .map((record) => record.trim())
+    .filter(Boolean)
+    .map((record) => {
+      const [sha, message] = record.split("\x1f", 2);
+      return { sha, message };
+    });
+}
+
+function releasedSourceShas(tag) {
+  const output = git(["log", "--format=%B", tag]);
+  return new Set(
+    [...output.matchAll(releaseSignalSourcePattern)].map((match) => match[1]),
+  );
+}
+
+function syntheticCommitEnvironment() {
+  return {
+    ...process.env,
+    GIT_AUTHOR_NAME:
+      process.env.GIT_AUTHOR_NAME ?? "command-ghostwriter release",
+    GIT_AUTHOR_EMAIL:
+      process.env.GIT_AUTHOR_EMAIL ?? "release@users.noreply.github.com",
+    GIT_COMMITTER_NAME:
+      process.env.GIT_COMMITTER_NAME ?? "command-ghostwriter release",
+    GIT_COMMITTER_EMAIL:
+      process.env.GIT_COMMITTER_EMAIL ?? "release@users.noreply.github.com",
+  };
+}
+
+function createSyntheticCommit(entry) {
+  const tree = git(["write-tree"]);
+  const parent = git(["rev-parse", "HEAD"]);
+  const body = [entry.body, `Release-Signal-Source: ${entry.sourceSha}`]
+    .filter(Boolean)
+    .join("\n\n");
+  const messageArgs = ["-m", entry.subject, "-m", body];
+  const commit = execFileSync(
+    "git",
+    ["commit-tree", tree, "-p", parent, ...messageArgs],
+    {
+      encoding: "utf8",
+      env: syntheticCommitEnvironment(),
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  ).trim();
+  git(["reset", "--soft", commit]);
+}
+
+ensureRef(developRef);
+const tag = latestReleaseTag();
+const commits = firstParentCommitsSince(tag, developRef);
+const releasedSources = releasedSourceShas(tag);
+const releaseEntries = commits
+  .filter((commit) => !releasedSources.has(commit.sha))
+  .map(releaseEntryFromCommit)
+  .filter((entry) => entry !== null)
+  .reverse();
+
+for (const entry of releaseEntries) {
+  createSyntheticCommit(entry);
+}
+
+console.log(
+  `prepare-release-commits: accepted ${releaseEntries.length} release title(s), ignored ${
+    commits.length - releaseEntries.length
+  } title(s) from ${developRef} since ${tag}`,
+);

--- a/tests/workflow/test_release_management.py
+++ b/tests/workflow/test_release_management.py
@@ -20,8 +20,10 @@ def load_release_config() -> dict[str, Any]:
 
 
 def run_git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    git = shutil.which("git")
+    assert git is not None
     return subprocess.run(
-        ["git", *args],
+        [git, *args],
         cwd=repo,
         check=True,
         capture_output=True,

--- a/tests/workflow/test_release_management.py
+++ b/tests/workflow/test_release_management.py
@@ -19,12 +19,65 @@ def load_release_config() -> dict[str, Any]:
         return json.load(config_file)
 
 
+def run_git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def commit_file(repo: Path, filename: str, content: str, message: str, *extra_message_args: str) -> None:
+    target = repo / filename
+    target.write_text(content, encoding="utf-8")
+    run_git(repo, "add", filename)
+    run_git(repo, "commit", "-m", message, *extra_message_args)
+
+
+def init_release_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run_git(repo, "init", "-b", "main")
+    run_git(repo, "config", "user.email", "release-test@example.com")
+    run_git(repo, "config", "user.name", "Release Test")
+    run_git(repo, "config", "commit.gpgsign", "false")
+    commit_file(repo, "README.md", "baseline\n", "chore: baseline")
+    run_git(repo, "tag", "v0.4.4")
+    run_git(repo, "checkout", "-b", "develop")
+    return repo
+
+
+def create_merge_commit(repo: Path, branch: str, filename: str, message: str) -> None:
+    run_git(repo, "checkout", "-b", branch, "main")
+    commit_file(repo, filename, f"{message}\n", message)
+    run_git(repo, "checkout", "develop")
+    run_git(repo, "merge", "--no-ff", branch, "-m", message)
+
+
+def create_github_merge_commit(repo: Path, branch: str, filename: str, pr_number: int, title: str) -> None:
+    run_git(repo, "checkout", "-b", branch, "main")
+    commit_file(repo, filename, f"{title}\n", title)
+    run_git(repo, "checkout", "develop")
+    run_git(
+        repo,
+        "merge",
+        "--no-ff",
+        branch,
+        "-m",
+        f"Merge pull request #{pr_number} from test/{branch}",
+        "-m",
+        title,
+    )
+
+
 def test_release_workflow_runs_on_schedule_and_manual_dispatch_only() -> None:
     workflow = load_workflow()
 
     assert workflow["name"] == "Release"
     assert set(workflow[True]) == {"schedule", "workflow_dispatch"}
-    assert workflow[True]["schedule"] == [{"cron": "17 1 * * 1"}]
+    assert workflow[True]["schedule"] == [{"cron": "0 21 * * *"}]
     assert "push" not in workflow[True]
     assert "pull_request" not in workflow[True]
 
@@ -44,6 +97,19 @@ def test_release_workflow_requires_baseline_tag_and_release_token_fallback() -> 
     baseline = next(step for step in steps if step["name"] == "Require a baseline tag")
     assert "git tag --list 'v[0-9]*.[0-9]*.[0-9]*'" in baseline["run"]
     assert "silently releasing 1.0.0" in baseline["run"]
+
+
+def test_release_workflow_prepares_develop_merge_title_commits() -> None:
+    workflow = load_workflow()
+    steps = workflow["jobs"]["release"]["steps"]
+
+    prepare = next(step for step in steps if step["name"] == "Prepare release commits from develop")
+    assert "git fetch origin develop:refs/remotes/origin/develop --tags" in prepare["run"]
+    assert "node scripts/prepare_release_commits.mjs origin/develop" in prepare["run"]
+
+    run_release_index = next(index for index, step in enumerate(steps) if step["name"] == "Run semantic-release")
+    prepare_index = steps.index(prepare)
+    assert prepare_index < run_release_index
 
 
 def test_release_workflow_invokes_semantic_release_with_required_plugins() -> None:
@@ -81,6 +147,204 @@ def test_release_config_updates_package_manifest_and_changelog() -> None:
             "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
         },
     ] in config["plugins"]
+
+
+def test_prepare_release_commits_creates_conventional_inputs_from_develop_merges(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    assert node is not None
+    repo = init_release_repo(tmp_path)
+    create_merge_commit(repo, "feature-one", "feature.txt", "feat: add generated command preview")
+    create_merge_commit(repo, "bugfix-one", "bugfix.txt", "fix: preserve uploaded csv values")
+    main_head = run_git(repo, "rev-parse", "main").stdout.strip()
+    run_git(repo, "checkout", "main")
+
+    result = subprocess.run(
+        [node, str(ROOT / "scripts" / "prepare_release_commits.mjs"), "develop"],
+        check=False,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    subjects = run_git(repo, "log", "--format=%s", f"{main_head}..HEAD").stdout.splitlines()
+    assert subjects == [
+        "fix: preserve uploaded csv values",
+        "feat: add generated command preview",
+    ]
+    assert "accepted 2 release title(s)" in result.stdout
+
+
+def test_prepare_release_commits_ignores_non_release_titles(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    assert node is not None
+    repo = init_release_repo(tmp_path)
+    create_merge_commit(repo, "docs-only", "docs.txt", "docs: clarify release setup")
+    main_head = run_git(repo, "rev-parse", "main").stdout.strip()
+    run_git(repo, "checkout", "main")
+
+    result = subprocess.run(
+        [node, str(ROOT / "scripts" / "prepare_release_commits.mjs"), "develop"],
+        check=False,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert run_git(repo, "rev-parse", "HEAD").stdout.strip() == main_head
+    assert "accepted 0 release title(s)" in result.stdout
+
+
+def test_prepare_release_commits_accepts_breaking_change_titles(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    assert node is not None
+    repo = init_release_repo(tmp_path)
+    create_merge_commit(repo, "breaking-one", "breaking.txt", "refactor!: simplify template API")
+    main_head = run_git(repo, "rev-parse", "main").stdout.strip()
+    run_git(repo, "checkout", "main")
+
+    result = subprocess.run(
+        [node, str(ROOT / "scripts" / "prepare_release_commits.mjs"), "develop"],
+        check=False,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    subjects = run_git(repo, "log", "--format=%s", f"{main_head}..HEAD").stdout.splitlines()
+    assert subjects == ["refactor!: simplify template API"]
+    assert "accepted 1 release title(s)" in result.stdout
+
+
+def test_prepare_release_commits_unwraps_github_merge_commit_body_titles(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    assert node is not None
+    repo = init_release_repo(tmp_path)
+    create_github_merge_commit(repo, "wrapped-feature", "wrapped.txt", 123, "feat: add wrapped PR title")
+    main_head = run_git(repo, "rev-parse", "main").stdout.strip()
+    run_git(repo, "checkout", "main")
+
+    result = subprocess.run(
+        [node, str(ROOT / "scripts" / "prepare_release_commits.mjs"), "develop"],
+        check=False,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    subjects = run_git(repo, "log", "--format=%s", f"{main_head}..HEAD").stdout.splitlines()
+    assert subjects == ["feat: add wrapped PR title"]
+    assert "accepted 1 release title(s)" in result.stdout
+
+
+def test_prepare_release_commits_accepts_first_parent_squash_titles(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    assert node is not None
+    repo = init_release_repo(tmp_path)
+    commit_file(repo, "squash.txt", "squash\n", "fix: accept squash merge title")
+    main_head = run_git(repo, "rev-parse", "main").stdout.strip()
+    run_git(repo, "checkout", "main")
+
+    result = subprocess.run(
+        [node, str(ROOT / "scripts" / "prepare_release_commits.mjs"), "develop"],
+        check=False,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    subjects = run_git(repo, "log", "--format=%s", f"{main_head}..HEAD").stdout.splitlines()
+    assert subjects == ["fix: accept squash merge title"]
+    assert "accepted 1 release title(s)" in result.stdout
+
+
+def test_prepare_release_commits_preserves_breaking_change_footer(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    assert node is not None
+    repo = init_release_repo(tmp_path)
+    commit_file(
+        repo,
+        "breaking-footer.txt",
+        "breaking footer\n",
+        "refactor: simplify template API",
+        "-m",
+        "BREAKING CHANGE: template filters are renamed",
+    )
+    main_head = run_git(repo, "rev-parse", "main").stdout.strip()
+    run_git(repo, "checkout", "main")
+
+    result = subprocess.run(
+        [node, str(ROOT / "scripts" / "prepare_release_commits.mjs"), "develop"],
+        check=False,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    subjects = run_git(repo, "log", "--format=%s", f"{main_head}..HEAD").stdout.splitlines()
+    body = run_git(repo, "log", "--format=%b", f"{main_head}..HEAD").stdout
+    assert subjects == ["refactor: simplify template API"]
+    assert "BREAKING CHANGE: template filters are renamed" in body
+    assert "accepted 1 release title(s)" in result.stdout
+
+
+def test_prepare_release_commits_skips_already_released_develop_commits(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    assert node is not None
+    repo = init_release_repo(tmp_path)
+    create_merge_commit(repo, "released-feature", "released.txt", "feat: release once")
+    main_head = run_git(repo, "rev-parse", "main").stdout.strip()
+    run_git(repo, "checkout", "main")
+
+    first_result = subprocess.run(
+        [node, str(ROOT / "scripts" / "prepare_release_commits.mjs"), "develop"],
+        check=False,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    assert first_result.returncode == 0, first_result.stderr
+    first_subjects = run_git(repo, "log", "--format=%s", f"{main_head}..HEAD").stdout.splitlines()
+    assert first_subjects == ["feat: release once"]
+    first_body = run_git(repo, "log", "--format=%b", "-1").stdout
+    assert "Release-Signal-Source:" in first_body
+
+    run_git(repo, "tag", "v0.4.5")
+    released_head = run_git(repo, "rev-parse", "HEAD").stdout.strip()
+    second_result = subprocess.run(
+        [node, str(ROOT / "scripts" / "prepare_release_commits.mjs"), "develop"],
+        check=False,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert second_result.returncode == 0, second_result.stderr
+    assert run_git(repo, "rev-parse", "HEAD").stdout.strip() == released_head
+    assert "accepted 0 release title(s)" in second_result.stdout
+
+
+def test_prepare_release_commits_fails_when_develop_ref_is_missing(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    assert node is not None
+    repo = init_release_repo(tmp_path)
+    run_git(repo, "checkout", "main")
+
+    result = subprocess.run(
+        [node, str(ROOT / "scripts" / "prepare_release_commits.mjs"), "origin/develop"],
+        check=False,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "develop ref not found: origin/develop" in result.stderr
 
 
 def test_apply_version_updates_package_json_and_lockfile(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Schedule the Release workflow for 06:00 JST and keep manual dispatch.
- Add a release preparation script that converts unreleased develop first-parent titles into local semantic-release input commits.
- Update versioning docs, design, and plan notes to describe the develop-title release signal and repeat-run marker behavior.

## Root cause
Release tags are created on main, while release-worthy development history lands on develop. A plain tag-to-develop range can re-read old develop titles after a release, so the new script records `Release-Signal-Source` markers and skips source commits already present in the latest tagged release history.

## Test plan
- `.venv/bin/python -m pytest tests/workflow/test_release_management.py -v` -> 15 passed
- `./node_modules/.bin/prettier --check .github/workflows/release.yml scripts/prepare_release_commits.mjs docs/versioning.md docs/superpowers/specs/2026-07-05-release-develop-merge-title-versioning-design.md docs/superpowers/plans/2026-07-05-release-develop-merge-title-versioning.md` -> pass

Closes #521