### PR TITLE
ci(release): keep develop signal commits local

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,19 +7,14 @@
       "@semantic-release/commit-analyzer",
       {
         "preset": "conventionalcommits",
-        "releaseRules": [
-          { "breaking": true, "release": "minor" }
-        ]
+        "releaseRules": [{ "breaking": true, "release": "minor" }]
       }
     ],
     [
       "@semantic-release/release-notes-generator",
       { "preset": "conventionalcommits" }
     ],
-    [
-      "@semantic-release/changelog",
-      { "changelogFile": "CHANGELOG.md" }
-    ],
+    ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
     [
       "@semantic-release/exec",
       { "prepareCmd": "node scripts/apply_version.mjs ${nextRelease.version}" }
@@ -27,7 +22,12 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
+        "assets": [
+          "package.json",
+          "package-lock.json",
+          "CHANGELOG.md",
+          ".release-signals.json"
+        ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -30,10 +30,17 @@ first-parent titles that landed on `develop`. Before semantic-release runs,
 common GitHub merge commit bodies when needed, and creates local synthetic
 Conventional Commit inputs on top of the checked-out `main` branch.
 
-Each synthetic input records the source `develop` commit SHA with a
-`Release-Signal-Source:` marker. Later scheduled runs read those markers from
-the latest release tag and skip already released `develop` commits, so old
-titles do not trigger a new release every morning.
+Those synthetic commits are temporary analysis inputs only. During release
+preparation, `scripts/apply_version.mjs` restores `HEAD` to the original `main`
+checkout before `@semantic-release/git` creates the release commit. This keeps
+the pushed `main` history limited to the normal release commit instead of
+publishing the synthetic inputs.
+
+Each release records the source `develop` commit SHAs in `.release-signals.json`.
+Later scheduled runs read that metadata from the latest release tag and skip
+already released `develop` commits, so old titles do not trigger a new release
+every morning. Historical `Release-Signal-Source:` commit markers are still
+recognized for compatibility.
 
 The release uses Conventional Commit titles:
 
@@ -53,6 +60,11 @@ breaking-change-to-major behavior.
 Create a repository secret named `RELEASE_TOKEN` with permission to write
 contents and pull requests. The workflow falls back to `GITHUB_TOKEN`, but that
 token may not be able to push the release commit through branch protection.
+When `main` is protected by repository rules, the release actor must either be
+allowed to bypass the pull-request requirement and signature requirement, or it
+must create verified commits that satisfy those rules. The release workflow only
+pushes the generated release commit; synthetic `develop` signal commits are
+discarded before the push.
 
 Seed the baseline tag once after this release management change lands on `main`:
 

--- a/scripts/apply_version.mjs
+++ b/scripts/apply_version.mjs
@@ -1,11 +1,25 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readFile, unlink, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
 const version = process.argv[2];
+const releaseMetadataPath = ".release-signals.json";
+const releaseStateGitPath = "command-ghostwriter-release-state.json";
 
-if (!version || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version)) {
+if (
+  !version ||
+  !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version)
+) {
   console.error("Usage: node scripts/apply_version.mjs <semver>");
   process.exit(1);
+}
+
+function git(args) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
 }
 
 async function readJson(path) {
@@ -17,9 +31,78 @@ async function writeJson(path, data) {
   await writeFile(path, `${JSON.stringify(data, null, 4)}\n`, "utf8");
 }
 
+async function readJsonIfExists(path, fallback) {
+  try {
+    return await readJson(path);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return fallback;
+    }
+    throw error;
+  }
+}
+
+async function restoreReleaseBaseAndReadState() {
+  let statePath;
+
+  try {
+    statePath = git(["rev-parse", "--git-path", releaseStateGitPath]);
+  } catch {
+    return null;
+  }
+
+  if (!existsSync(statePath)) {
+    return null;
+  }
+
+  const state = await readJson(statePath);
+  if (!/^[0-9a-f]{40}$/.test(state.baseHead ?? "")) {
+    throw new Error(`Invalid release base head in ${statePath}`);
+  }
+
+  git(["rev-parse", "--verify", `${state.baseHead}^{commit}`]);
+
+  if (git(["rev-parse", "HEAD"]) !== state.baseHead) {
+    git(["reset", "--soft", state.baseHead]);
+  }
+
+  return { ...state, statePath };
+}
+
+async function recordReleaseSources(state) {
+  const sources = state?.sources ?? [];
+  if (sources.length === 0) {
+    return;
+  }
+
+  const metadata = await readJsonIfExists(releaseMetadataPath, {
+    releasedSources: [],
+  });
+  const seen = new Set(
+    metadata.releasedSources.map((source) => source.sourceSha),
+  );
+
+  for (const source of sources) {
+    if (
+      /^[0-9a-f]{40}$/.test(source.sourceSha ?? "") &&
+      !seen.has(source.sourceSha)
+    ) {
+      metadata.releasedSources.push({
+        sourceSha: source.sourceSha,
+        version,
+        subject: source.subject,
+      });
+      seen.add(source.sourceSha);
+    }
+  }
+
+  await writeJson(releaseMetadataPath, metadata);
+}
+
 const packageJsonPath = resolve("package.json");
 const packageLockPath = resolve("package-lock.json");
 
+const releaseState = await restoreReleaseBaseAndReadState();
 const packageJson = await readJson(packageJsonPath);
 packageJson.version = version;
 await writeJson(packageJsonPath, packageJson);
@@ -37,6 +120,12 @@ try {
   if (error.code !== "ENOENT") {
     throw error;
   }
+}
+
+await recordReleaseSources(releaseState);
+
+if (releaseState?.statePath) {
+  await unlink(releaseState.statePath);
 }
 
 console.log(`Applied version ${version}`);

--- a/scripts/prepare_release_commits.mjs
+++ b/scripts/prepare_release_commits.mjs
@@ -1,6 +1,9 @@
 import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
 
 const developRef = process.argv[2] ?? "origin/develop";
+const releaseMetadataPath = ".release-signals.json";
+const releaseStateGitPath = "command-ghostwriter-release-state.json";
 const conventionalSubjectPattern = /^[a-z][a-z0-9-]*(?:\([^)]+\))?!?: .+$/;
 const releaseSubjectPattern =
   /^(?:(?:feat|fix)(?:\([^)]+\))?!?: .+|[a-z][a-z0-9-]*(?:\([^)]+\))?!: .+)$/;
@@ -20,6 +23,14 @@ function gitQuiet(args) {
     return true;
   } catch {
     return false;
+  }
+}
+
+function gitOptional(args) {
+  try {
+    return git(args);
+  } catch {
+    return null;
   }
 }
 
@@ -97,8 +108,44 @@ function firstParentCommitsSince(tag, ref) {
 
 function releasedSourceShas(tag) {
   const output = git(["log", "--format=%B", tag]);
-  return new Set(
+  const sources = new Set(
     [...output.matchAll(releaseSignalSourcePattern)].map((match) => match[1]),
+  );
+  const metadata = gitOptional(["show", `${tag}:${releaseMetadataPath}`]);
+
+  if (metadata) {
+    try {
+      const parsed = JSON.parse(metadata);
+      for (const entry of parsed.releasedSources ?? []) {
+        if (/^[0-9a-f]{40}$/.test(entry.sourceSha ?? "")) {
+          sources.add(entry.sourceSha);
+        }
+      }
+    } catch {
+      // Ignore malformed historical metadata and fall back to commit trailers.
+    }
+  }
+
+  return sources;
+}
+
+function writeReleaseState(baseHead, tag, releaseEntries) {
+  const statePath = git(["rev-parse", "--git-path", releaseStateGitPath]);
+  writeFileSync(
+    statePath,
+    `${JSON.stringify(
+      {
+        baseHead,
+        latestTag: tag,
+        sources: releaseEntries.map((entry) => ({
+          sourceSha: entry.sourceSha,
+          subject: entry.subject,
+        })),
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
   );
 }
 
@@ -137,6 +184,7 @@ function createSyntheticCommit(entry) {
 
 ensureRef(developRef);
 const tag = latestReleaseTag();
+const baseHead = git(["rev-parse", "HEAD"]);
 const commits = firstParentCommitsSince(tag, developRef);
 const releasedSources = releasedSourceShas(tag);
 const releaseEntries = commits
@@ -144,6 +192,8 @@ const releaseEntries = commits
   .map(releaseEntryFromCommit)
   .filter((entry) => entry !== null)
   .reverse();
+
+writeReleaseState(baseHead, tag, releaseEntries);
 
 for (const entry of releaseEntries) {
   createSyntheticCommit(entry);

--- a/tests/workflow/test_release_management.py
+++ b/tests/workflow/test_release_management.py
@@ -145,7 +145,7 @@ def test_release_config_updates_package_manifest_and_changelog() -> None:
     assert [
         "@semantic-release/git",
         {
-            "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
+            "assets": ["package.json", "package-lock.json", "CHANGELOG.md", ".release-signals.json"],
             "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
         },
     ] in config["plugins"]
@@ -173,6 +173,13 @@ def test_prepare_release_commits_creates_conventional_inputs_from_develop_merges
     assert subjects == [
         "fix: preserve uploaded csv values",
         "feat: add generated command preview",
+    ]
+    state_path = run_git(repo, "rev-parse", "--git-path", "command-ghostwriter-release-state.json").stdout.strip()
+    state = json.loads((repo / state_path).read_text(encoding="utf-8"))
+    assert state["baseHead"] == main_head
+    assert [source["subject"] for source in state["sources"]] == [
+        "feat: add generated command preview",
+        "fix: preserve uploaded csv values",
     ]
     assert "accepted 2 release title(s)" in result.stdout
 
@@ -331,6 +338,39 @@ def test_prepare_release_commits_skips_already_released_develop_commits(tmp_path
     assert "accepted 0 release title(s)" in second_result.stdout
 
 
+def test_prepare_release_commits_skips_sources_recorded_in_release_metadata(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    assert node is not None
+    repo = init_release_repo(tmp_path)
+    create_merge_commit(repo, "released-feature", "released.txt", "feat: release once")
+    source_sha = run_git(repo, "rev-parse", "develop").stdout.strip()
+    run_git(repo, "checkout", "main")
+    metadata = {
+        "releasedSources": [
+            {
+                "sourceSha": source_sha,
+                "version": "0.4.5",
+                "subject": "feat: release once",
+            }
+        ]
+    }
+    commit_file(repo, ".release-signals.json", json.dumps(metadata), "chore(release): 0.4.5 [skip ci]")
+    run_git(repo, "tag", "v0.4.5")
+    released_head = run_git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    result = subprocess.run(
+        [node, str(ROOT / "scripts" / "prepare_release_commits.mjs"), "develop"],
+        check=False,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert run_git(repo, "rev-parse", "HEAD").stdout.strip() == released_head
+    assert "accepted 0 release title(s)" in result.stdout
+
+
 def test_prepare_release_commits_fails_when_develop_ref_is_missing(tmp_path: Path) -> None:
     node = shutil.which("node")
     assert node is not None
@@ -387,3 +427,61 @@ def test_apply_version_updates_package_json_and_lockfile(tmp_path: Path) -> None
     assert lock_data["version"] == "0.4.0"
     assert lock_data["packages"][""]["version"] == "0.4.0"
     assert lock_data["packages"]["node_modules/example"]["version"] == "1.0.0"
+
+
+def test_apply_version_restores_release_base_and_records_sources(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    assert node is not None
+    repo = init_release_repo(tmp_path)
+    run_git(repo, "checkout", "main")
+    (repo / "package.json").write_text(
+        json.dumps({"name": "command_ghostwriter", "version": "0.4.4"}),
+        encoding="utf-8",
+    )
+    (repo / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "name": "command_ghostwriter",
+                "version": "0.4.4",
+                "packages": {"": {"name": "command_ghostwriter", "version": "0.4.4"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    run_git(repo, "add", "package.json", "package-lock.json")
+    run_git(repo, "commit", "-m", "chore: add package manifests")
+    create_merge_commit(repo, "feature-one", "feature.txt", "feat: add generated command preview")
+    main_head = run_git(repo, "rev-parse", "main").stdout.strip()
+    source_sha = run_git(repo, "rev-parse", "develop").stdout.strip()
+    run_git(repo, "checkout", "main")
+
+    prepare_result = subprocess.run(
+        [node, str(ROOT / "scripts" / "prepare_release_commits.mjs"), "develop"],
+        check=False,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    assert prepare_result.returncode == 0, prepare_result.stderr
+    assert run_git(repo, "rev-parse", "HEAD").stdout.strip() != main_head
+    (repo / "CHANGELOG.md").write_text("## 0.5.0\n\n- generated notes\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [node, str(ROOT / "scripts" / "apply_version.mjs"), "0.5.0"],
+        check=False,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert run_git(repo, "rev-parse", "HEAD").stdout.strip() == main_head
+    assert run_git(repo, "log", "--format=%s", f"{main_head}..HEAD").stdout.splitlines() == []
+    metadata = json.loads((repo / ".release-signals.json").read_text(encoding="utf-8"))
+    assert metadata["releasedSources"] == [
+        {
+            "sourceSha": source_sha,
+            "version": "0.5.0",
+            "subject": "feat: add generated command preview",
+        }
+    ]


### PR DESCRIPTION
## Summary
- Keep synthetic develop release signal commits as semantic-release analysis inputs only.
- Restore HEAD to the original main checkout before @semantic-release/git creates and pushes the release commit.
- Record released develop source SHAs in .release-signals.json so scheduled releases do not repeat the same develop titles.
- Document the remaining ruleset requirement for the actual release commit actor.

## Verification
- .venv/bin/python -m pytest tests/workflow/test_release_management.py -v
- .venv/bin/ruff check . -v
- node_modules/.bin/prettier --check .releaserc.json scripts/prepare_release_commits.mjs scripts/apply_version.mjs docs/versioning.md

## Notes
- Full npm test is blocked locally because the project requires uv==0.8.17 but this machine has uv 0.11.11.
- Direct .venv full pytest reached 438 passed / 4 failed; the failures are local pyenv path issues where /Users/tvna/.pyenv/shims/python3 cannot find /opt/homebrew/opt/pyenv/bin/pyenv.

Closes #523.