### PR TITLE
fix(release): unblock version-bump CI (ruleset bypass docs + --no-ci)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
         # Versions pinned by major. semantic-release runs on the runner's
         # preinstalled Node; no release dependencies are committed to this repo.
+        #
+        # --no-ci is required, not optional. The "Prepare release commits from
+        # develop" step builds synthetic Conventional Commit inputs on top of the
+        # checked-out main, which moves local HEAD off the remote main SHA.
+        # semantic-release's isBranchUpToDate compares `git rev-parse HEAD` with
+        # the remote branch SHA by strict equality; the moved HEAD makes that
+        # check fail, so without --no-ci semantic-release logs "the local branch
+        # main is behind the remote one" and publishes nothing. --no-ci skips that
+        # CI branch-sync verification. It does not force a dry run, so the release
+        # still publishes. Safety is preserved by the workflow-level concurrency
+        # serialization and by git's fast-forward requirement on the final push,
+        # which still fails loudly if main advanced underneath us.
         run: >
           npx --yes
           -p semantic-release@^24
@@ -75,4 +87,4 @@ jobs:
           -p @semantic-release/git@^10
           -p @semantic-release/github@^11
           -p conventional-changelog-conventionalcommits@^8
-          semantic-release
+          semantic-release --no-ci

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -57,14 +57,52 @@ breaking-change-to-major behavior.
 
 ## Required Setup
 
-Create a repository secret named `RELEASE_TOKEN` with permission to write
-contents and pull requests. The workflow falls back to `GITHUB_TOKEN`, but that
-token may not be able to push the release commit through branch protection.
-When `main` is protected by repository rules, the release actor must either be
-allowed to bypass the pull-request requirement and signature requirement, or it
-must create verified commits that satisfy those rules. The release workflow only
-pushes the generated release commit; synthetic `develop` signal commits are
-discarded before the push.
+### Why the release needs a bypass actor
+
+`@semantic-release/git` pushes the generated release commit directly to `main`
+with `git push --tags HEAD:main`. When `main` carries a repository ruleset that
+requires pull requests and verified signatures, that direct push is rejected
+with `GH013` unless the pushing identity is on the ruleset **Bypass list**:
+
+- **Changes must be made through a pull request** can only be satisfied by a
+  bypass actor. Nothing in semantic-release turns its own direct push into a PR.
+- **Commits must have verified signatures** is also waived for a bypass actor,
+  because a ruleset bypass waives every rule in that ruleset at once. Signing the
+  commit alone does not help while the pull-request rule is still enforced.
+
+The default `GITHUB_TOKEN` runs as `github-actions[bot]`, which is never a bypass
+actor, so a release run without `RELEASE_TOKEN` fails at the final push. The
+workflow only pushes the single generated release commit; the synthetic
+`develop` signal commits are discarded before the push.
+
+### Configure `RELEASE_TOKEN` as a bypass actor
+
+Pick one identity and add it to the `main` ruleset Bypass list
+(Settings -> Rules -> Rulesets -> the `main` ruleset -> Bypass list):
+
+- **GitHub App (preferred, permanent).** Create/install a repo-scoped App with
+  Repository permissions `Contents: Read and write` and `Pull requests: Read and
+  write`, add the App to the Bypass list, and store an installation token as the
+  `RELEASE_TOKEN` secret. An App is not tied to a personal account and is the
+  smallest durable bypass surface.
+- **Fine-grained PAT (acceptable temporary workaround).** Create a fine-grained
+  PAT scoped to this repository only, with `Contents: Read and write` and
+  `Pull requests: Read and write`, a short expiry (<= 90 days), then add its owner
+  to the Bypass list. Rotate before expiry and replace with the App when ready.
+
+Store the token as the repository secret `RELEASE_TOKEN`
+(Settings -> Secrets and variables -> Actions). Never paste the token value into
+issues, PRs, logs, or commits.
+
+Grant only the two write permissions above; do not widen scope to chase the
+push failure. A broad or long-lived bypass token is the main security risk here.
+
+### Verify the handoff without exposing the secret
+
+Run `Release` via `workflow_dispatch` from `main` and confirm the
+`Run semantic-release` step reaches the push without a `GH013` rejection. A
+missing or non-bypass token surfaces as the `remote rejected ... repository rule
+violations` error, not as a leaked value, so the failure mode is safe to inspect.
 
 Seed the baseline tag once after this release management change lands on `main`:
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -87,8 +87,9 @@ Pick one identity and add it to the `main` ruleset Bypass list
   static secret would break the daily scheduled release as soon as it ages out.
   Instead store the App's `app-id` and `private-key` as secrets and mint a fresh
   installation token inside the workflow before Checkout (for example with
-  `actions/create-github-app-token`), then pass its output as the Checkout token
-  and the `GITHUB_TOKEN` env. An App is not tied to a personal account and is the
+  `actions/create-github-app-token`, pinned to a commit SHA to match this repo's
+  action-pinning convention), then pass its output as the Checkout token and the
+  `GITHUB_TOKEN` env. An App is not tied to a personal account and is the
   smallest durable bypass surface. The workflow as written consumes a single
   static `RELEASE_TOKEN` secret, which fits the PAT path below directly; choosing
   the App path additionally requires adding that token-minting step.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -82,17 +82,26 @@ Pick one identity and add it to the `main` ruleset Bypass list
 
 - **GitHub App (preferred, permanent).** Create/install a repo-scoped App with
   Repository permissions `Contents: Read and write` and `Pull requests: Read and
-  write`, add the App to the Bypass list, and store an installation token as the
-  `RELEASE_TOKEN` secret. An App is not tied to a personal account and is the
-  smallest durable bypass surface.
+  write`, and add the App to the Bypass list. Do NOT store a raw installation
+  token: GitHub App installation access tokens expire after about one hour, so a
+  static secret would break the daily scheduled release as soon as it ages out.
+  Instead store the App's `app-id` and `private-key` as secrets and mint a fresh
+  installation token inside the workflow before Checkout (for example with
+  `actions/create-github-app-token`), then pass its output as the Checkout token
+  and the `GITHUB_TOKEN` env. An App is not tied to a personal account and is the
+  smallest durable bypass surface. The workflow as written consumes a single
+  static `RELEASE_TOKEN` secret, which fits the PAT path below directly; choosing
+  the App path additionally requires adding that token-minting step.
 - **Fine-grained PAT (acceptable temporary workaround).** Create a fine-grained
   PAT scoped to this repository only, with `Contents: Read and write` and
   `Pull requests: Read and write`, a short expiry (<= 90 days), then add its owner
   to the Bypass list. Rotate before expiry and replace with the App when ready.
 
-Store the token as the repository secret `RELEASE_TOKEN`
-(Settings -> Secrets and variables -> Actions). Never paste the token value into
-issues, PRs, logs, or commits.
+For the PAT path, store the token as the repository secret `RELEASE_TOKEN`
+(Settings -> Secrets and variables -> Actions). For the App path, store the
+`app-id` and `private-key` secrets instead and mint the token at runtime as
+described above. Never paste a token or private key value into issues, PRs, logs,
+or commits.
 
 Grant only the two write permissions above; do not widen scope to chase the
 push failure. A broad or long-lived bypass token is the main security risk here.

--- a/tests/workflow/test_release_management.py
+++ b/tests/workflow/test_release_management.py
@@ -120,6 +120,10 @@ def test_release_workflow_invokes_semantic_release_with_required_plugins() -> No
     command = run_step["run"]
 
     assert run_step["env"]["GITHUB_TOKEN"] == "${{ secrets.RELEASE_TOKEN || github.token }}"
+    # The prepare step moves local HEAD off the remote main SHA (synthetic commits),
+    # which trips semantic-release's strict isBranchUpToDate check. --no-ci skips that
+    # CI branch-sync verification so the release is analyzed and published.
+    assert "semantic-release --no-ci" in command
     for package in [
         "semantic-release@^24",
         "@semantic-release/commit-analyzer@^13",


### PR DESCRIPTION
## What

Fixes the develop->main version-bump release path, which was failing in two stages.

### 1. Push to protected main rejected (GH013) - docs (#525)
`@semantic-release/git` pushes the release commit directly to `main`. The `main`
ruleset (PR required + verified signatures) rejects that push unless the pushing
identity is a ruleset bypass actor. Sharpened `docs/versioning.md` Required Setup
into a runbook: identity choice (GitHub App preferred, fine-grained PAT as a
scoped temporary workaround), minimum permissions, the Bypass-list step, rotation
cadence, and a non-secret-exposing verification. (Configuring the secret + bypass
is an owner action; no code enforces it.)

### 2. CI green but nothing published - `--no-ci` (#526)
After the bypass was configured the push stage was reached and CI went green, but
semantic-release published nothing, logging "the local branch main is behind the
remote one". Root cause: semantic-release v24 `isBranchUpToDate` compares
`git rev-parse HEAD` with the remote main SHA by strict equality. The
"Prepare release commits from develop" step builds synthetic Conventional Commit
inputs on top of the checked-out main, moving local HEAD off the remote main SHA,
so the check fails and semantic-release aborts before analyzeCommits. Added
`--no-ci` to skip that CI branch-sync verification (it does not force a dry run, so
the release still publishes). Safety is preserved by the workflow `concurrency`
serialization and git's fast-forward requirement on the final push.

## Tests
- `tests/workflow/test_release_management.py` asserts `semantic-release --no-ci` in
  the workflow command. Full file: 17 passed locally.

## Notes / follow-up (not in this PR)
- Version baseline reconciliation (owner git-ops): the highest tag reachable from
  `main` is `v0.3.6`, but `package.json` is `0.4.4` and `v0.4.1..v0.4.4` point to
  an orphaned old `main` line. Without reconciliation the first release after this
  merge would cut a backwards `0.4.0`. A reachable `v0.4.4` baseline must be
  established before running Release. Attempting this from the automation
  environment is blocked (git relay returns 403 on tag ref updates), so it needs
  to be done with owner repo permissions.
- Behavioral verification of `--no-ci` can only happen on the next Release run
  from `main` after this merge.

Refs #525, #526

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9J45R53KbBS4mAB4Kocap)_