### PR TITLE
feat(web): editor UX polish for the 2-pane editor (#529)

### DIFF
--- a/web/src/components/Editor.test.tsx
+++ b/web/src/components/Editor.test.tsx
@@ -1,13 +1,19 @@
 // @vitest-environment jsdom
 // NOTE: These tests replaced the old textarea-based Editor tests (stale after P2 redesign port).
 // The new Editor is the full two-pane Pyodide-backed editor; smoke-test that it mounts.
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
 
 // jsdom has no real Worker; mock the worker module so useGenerate's mount doesn't crash.
+// The mock records each constructed instance so a test can drive its onmessage handler
+// (simulating the worker posting `ready` / `result`).
+const workerInstances: Array<{ onmessage: ((e: MessageEvent) => void) | null }> = [];
 vi.mock("../worker/generate.worker?worker", () => ({
   default: class {
     onmessage: ((e: MessageEvent) => void) | null = null;
+    constructor() {
+      workerInstances.push(this);
+    }
     postMessage() {}
     terminate() {}
   },
@@ -18,28 +24,66 @@ import { DEFAULT_SETTINGS } from "../worker/types";
 
 const defaultDownload = { enc: "UTF-8" as const, fname: "output", ts: false, ext: "txt" };
 
+function renderEditor() {
+  return render(
+    <Editor
+      settings={DEFAULT_SETTINGS}
+      onSettings={() => {}}
+      download={defaultDownload}
+      onDownload={() => {}}
+    />,
+  );
+}
+
+afterEach(() => {
+  workerInstances.length = 0;
+  vi.useRealTimers();
+});
+
 describe("Editor (redesign-b)", () => {
   it("renders the app bar title", () => {
-    render(
-      <Editor
-        settings={DEFAULT_SETTINGS}
-        onSettings={() => {}}
-        download={defaultDownload}
-        onDownload={() => {}}
-      />,
-    );
+    renderEditor();
     expect(screen.getByText("Command ghostwriter")).toBeTruthy();
   });
 
   it("renders the 詳細設定 button", () => {
-    render(
-      <Editor
-        settings={DEFAULT_SETTINGS}
-        onSettings={() => {}}
-        download={defaultDownload}
-        onDownload={() => {}}
-      />,
-    );
+    renderEditor();
     expect(screen.getByText("詳細設定")).toBeTruthy();
+  });
+
+  it("keeps the initializing state until the first worker result arrives", () => {
+    vi.useFakeTimers();
+    renderEditor();
+
+    // Before bootstrap: the output pane shows the initializing state.
+    expect(screen.getByText("実行環境を初期化しています…")).toBeTruthy();
+    expect((screen.getByRole("button", { name: "コピー" }) as HTMLButtonElement).disabled).toBe(true);
+
+    const worker = workerInstances[0];
+    expect(worker?.onmessage).toBeTypeOf("function");
+
+    // Worker reports `ready`, but no generate result has come back yet.
+    // Regression guard: the pane must NOT flip to an empty result with enabled
+    // copy/save during this window (the debounced first generate is still pending).
+    act(() => {
+      worker.onmessage!({ data: { kind: "ready" } } as MessageEvent);
+    });
+    expect(screen.getByText("実行環境を初期化しています…")).toBeTruthy();
+    expect((screen.getByRole("button", { name: "コピー" }) as HTMLButtonElement).disabled).toBe(true);
+
+    // Let the debounced dispatch fire, then deliver the first result.
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    act(() => {
+      worker.onmessage!({
+        data: { kind: "result", id: 1, result: { output: "HELLO WORLD\n", configError: null, templateError: null, configDebug: "{}" } },
+      } as MessageEvent);
+    });
+
+    // Now the real output is available: initializing gone, copy enabled.
+    expect(screen.queryByText("実行環境を初期化しています…")).toBeNull();
+    expect(screen.getByText("HELLO WORLD")).toBeTruthy();
+    expect((screen.getByRole("button", { name: "コピー" }) as HTMLButtonElement).disabled).toBe(false);
   });
 });

--- a/web/src/components/Editor.tsx
+++ b/web/src/components/Editor.tsx
@@ -125,29 +125,52 @@ export function Editor({ initial, onBack, settings, onSettings, download, onDown
   const dataErrLine = computeDataErrLine(r);
   const enc = download.enc;
 
-  // Draggable split between the two panes. `leftFrac` is the left pane's share
-  // of the workspace width (clamped so neither pane collapses).
+  // Draggable split between the two panes. `leftFrac` is the committed left-pane
+  // width fraction (clamped so neither pane collapses). During a drag we mutate
+  // the grid template imperatively via rAF instead of calling setState on every
+  // pointer move, so we don't re-render the whole editor tree (both CodeView
+  // panes + MarkdownView) per event; state is committed once on pointer-up. The
+  // columns are applied from a layout effect rather than React inline style so
+  // an unrelated re-render mid-drag can't clobber the in-progress value.
   const workspaceRef = React.useRef<HTMLDivElement>(null);
   const [leftFrac, setLeftFrac] = React.useState(0.5);
+  const dragCleanupRef = React.useRef<(() => void) | null>(null);
+
+  React.useLayoutEffect(() => {
+    const ws = workspaceRef.current;
+    if (ws) ws.style.gridTemplateColumns = `${leftFrac}fr 7px ${1 - leftFrac}fr`;
+  }, [leftFrac]);
+  // Tear down an in-flight drag if the editor unmounts before pointer-up, so the
+  // window listeners and the global body cursor/user-select don't leak.
+  React.useEffect(() => () => dragCleanupRef.current?.(), []);
+
   const startResize = (e: React.PointerEvent) => {
     e.preventDefault();
     const ws = workspaceRef.current;
     if (!ws) return;
-    const rect = ws.getBoundingClientRect();
+    let frac = leftFrac;
+    let raf = 0;
     const onMove = (ev: PointerEvent) => {
-      const frac = (ev.clientX - rect.left) / rect.width;
-      setLeftFrac(Math.min(0.8, Math.max(0.2, frac)));
+      const rect = ws.getBoundingClientRect();
+      frac = Math.min(0.8, Math.max(0.2, (ev.clientX - rect.left) / rect.width));
+      if (!raf) raf = requestAnimationFrame(() => { raf = 0; ws.style.gridTemplateColumns = `${frac}fr 7px ${1 - frac}fr`; });
     };
-    const onUp = () => {
+    const teardown = () => {
+      if (raf) cancelAnimationFrame(raf);
       window.removeEventListener('pointermove', onMove);
       window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onUp);
       document.body.style.cursor = '';
       document.body.style.userSelect = '';
+      dragCleanupRef.current = null;
     };
+    const onUp = () => { teardown(); setLeftFrac(frac); };
+    dragCleanupRef.current = teardown;
     document.body.style.cursor = 'col-resize';
     document.body.style.userSelect = 'none';
     window.addEventListener('pointermove', onMove);
     window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onUp);
   };
 
   return (
@@ -157,7 +180,7 @@ export function Editor({ initial, onBack, settings, onSettings, download, onDown
       <AppBar tpl={tpl} blocked={blocked} onBack={onBack} onHowto={() => setHowto(true)} onSettings={() => setSettingsOpen(true)} />
 
       {/* ===== Workspace ===== */}
-      <div ref={workspaceRef} style={{ flex: 1, display: 'grid', gridTemplateColumns: `${leftFrac}fr 7px ${1 - leftFrac}fr`, gridTemplateRows: 'minmax(0, 1fr)', minHeight: 0 }}>
+      <div ref={workspaceRef} style={{ flex: 1, display: 'grid', gridTemplateRows: 'minmax(0, 1fr)', minHeight: 0 }}>
 
         {/* ---- LEFT: input ---- */}
         <LeftPane

--- a/web/src/components/Editor.tsx
+++ b/web/src/components/Editor.tsx
@@ -59,7 +59,7 @@ function Segmented({ items, value, onChange }: { items: SegItem[]; value: string
 
 function PaneHeader({ children }: { children: ReactNode }) {
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)', padding: '10px 14px', borderBottom: '1px solid var(--cg-border)', background: 'var(--cg-bg-secondary)', minHeight: 30 }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)', padding: '10px 14px', borderBottom: '1px solid var(--cg-border)', background: 'var(--cg-bg-secondary)', minHeight: 30, userSelect: 'none' }}>
       {children}
     </div>
   );
@@ -70,7 +70,7 @@ function StatusBar({ children, tone }: { children: ReactNode; tone?: 'ok' | 'err
   const bg = tone === 'err' ? 'var(--cg-error-bg)' : 'var(--cg-bg-secondary)';
   const bd = tone === 'err' ? 'var(--cg-error-border)' : 'var(--cg-border)';
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)', padding: '7px 14px', borderTop: `1px solid ${bd}`, background: bg, fontFamily: 'var(--font-mono)', fontSize: 'var(--text-xs)', color: c }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)', padding: '7px 14px', borderTop: `1px solid ${bd}`, background: bg, fontFamily: 'var(--font-mono)', fontSize: 'var(--text-xs)', color: c, userSelect: 'none' }}>
       {children}
     </div>
   );
@@ -125,6 +125,31 @@ export function Editor({ initial, onBack, settings, onSettings, download, onDown
   const dataErrLine = computeDataErrLine(r);
   const enc = download.enc;
 
+  // Draggable split between the two panes. `leftFrac` is the left pane's share
+  // of the workspace width (clamped so neither pane collapses).
+  const workspaceRef = React.useRef<HTMLDivElement>(null);
+  const [leftFrac, setLeftFrac] = React.useState(0.5);
+  const startResize = (e: React.PointerEvent) => {
+    e.preventDefault();
+    const ws = workspaceRef.current;
+    if (!ws) return;
+    const rect = ws.getBoundingClientRect();
+    const onMove = (ev: PointerEvent) => {
+      const frac = (ev.clientX - rect.left) / rect.width;
+      setLeftFrac(Math.min(0.8, Math.max(0.2, frac)));
+    };
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  };
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', minHeight: 620, minWidth: 1024, background: 'var(--cg-bg)', fontFamily: 'var(--font-sans)', color: 'var(--cg-text)' }}>
 
@@ -132,7 +157,7 @@ export function Editor({ initial, onBack, settings, onSettings, download, onDown
       <AppBar tpl={tpl} blocked={blocked} onBack={onBack} onHowto={() => setHowto(true)} onSettings={() => setSettingsOpen(true)} />
 
       {/* ===== Workspace ===== */}
-      <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 7px 1fr', gridTemplateRows: 'minmax(0, 1fr)', minHeight: 0 }}>
+      <div ref={workspaceRef} style={{ flex: 1, display: 'grid', gridTemplateColumns: `${leftFrac}fr 7px ${1 - leftFrac}fr`, gridTemplateRows: 'minmax(0, 1fr)', minHeight: 0 }}>
 
         {/* ---- LEFT: input ---- */}
         <LeftPane
@@ -149,8 +174,14 @@ export function Editor({ initial, onBack, settings, onSettings, download, onDown
           r={r}
         />
 
-        {/* resizer */}
-        <div style={{ background: 'var(--cg-border)', cursor: 'col-resize', display: 'grid', placeItems: 'center' }}>
+        {/* resizer — drag to reallocate width between the panes */}
+        <div
+          onPointerDown={startResize}
+          role="separator"
+          aria-orientation="vertical"
+          title="ドラッグして幅を調整"
+          style={{ background: 'var(--cg-border)', cursor: 'col-resize', display: 'grid', placeItems: 'center', touchAction: 'none', userSelect: 'none' }}
+        >
           <div style={{ width: 3, height: 28, borderRadius: 2, background: 'var(--cg-border-strong)' }} />
         </div>
 
@@ -197,7 +228,7 @@ type GenResult = ReturnType<typeof useGenerate>;
 
 function AppBar({ tpl, blocked, onBack, onHowto, onSettings }: { tpl: Template | null; blocked: boolean; onBack?: () => void; onHowto: () => void; onSettings: () => void }) {
   return (
-    <header style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-4)', padding: '0 18px', height: 56, borderBottom: '1px solid var(--cg-border)', flexShrink: 0 }}>
+    <header style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-4)', padding: '0 18px', height: 56, borderBottom: '1px solid var(--cg-border)', flexShrink: 0, userSelect: 'none' }}>
       {onBack && (
         <button onClick={onBack} title="戻る" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: 30, height: 30, flexShrink: 0, cursor: 'pointer', background: 'transparent', border: '1px solid var(--cg-border)', borderRadius: 'var(--radius-md)', color: 'var(--cg-text-muted)', fontSize: 16, lineHeight: 1 }}>←</button>
       )}
@@ -345,8 +376,8 @@ function OutputActions({ enc, download, onDownload, blocked, r, fire }: { enc: D
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
       <Selectbox value={enc} options={['UTF-8', 'Shift_JIS']} onChange={(v) => onDownload({ ...download, enc: v as DownloadOptions['enc'] })} style={{ width: 152 }} />
-      <Button variant="secondary" size="sm" disabled={blocked} icon={<Icon name="copy" size={14} />} onClick={() => { void navigator.clipboard.writeText(r.output); fire('コピーしました'); }}>コピー</Button>
-      <Button variant="primary" size="sm" disabled={blocked} icon={<Icon name="download" size={14} />} onClick={() => {
+      <Button variant="secondary" size="sm" disabled={blocked || !r.ready} icon={<Icon name="copy" size={14} />} onClick={() => { void navigator.clipboard.writeText(r.output); fire('コピーしました'); }}>コピー</Button>
+      <Button variant="primary" size="sm" disabled={blocked || !r.ready} icon={<Icon name="download" size={14} />} onClick={() => {
         const e: DownloadEncoding = enc === 'Shift_JIS' ? 'Shift_JIS' : 'utf-8';
         triggerDownload(r.output, downloadFilename(download.fname, download.ext, download.ts), e);
         fire('ダウンロードを開始');
@@ -356,6 +387,12 @@ function OutputActions({ enc, download, onDownload, blocked, r, fire }: { enc: D
 }
 
 function OutputBody({ rightMode, format, setFormat, blocked, r }: { rightMode: 'md' | 'raw' | 'debug'; format: Format; setFormat: (f: Format) => void; blocked: boolean; r: GenResult }) {
+  // Show the initializing state only while genuinely loading. If the worker
+  // reported a bootstrap error, `blocked` is set and we fall through to
+  // BlockedOutput so the failure surfaces rather than spinning forever.
+  if (!r.ready && !blocked) {
+    return <InitializingOutput />;
+  }
   if (blocked) {
     return <BlockedOutput format={format} error={r.error} suggest={r.suggest} onFix={() => r.suggest && setFormat(r.suggest)} />;
   }
@@ -369,6 +406,14 @@ function OutputBody({ rightMode, format, setFormat, blocked, r }: { rightMode: '
 }
 
 function RightStatusBar({ rightMode, enc, blocked, r }: { rightMode: 'md' | 'raw' | 'debug'; enc: DownloadOptions['enc']; blocked: boolean; r: GenResult }) {
+  if (!r.ready && !blocked) {
+    return (
+      <StatusBar>
+        <span className="cg-spin" style={{ width: 11, height: 11, borderRadius: '50%', border: '2px solid var(--cg-border)', borderTopColor: 'var(--cg-red)', display: 'inline-block' }} />
+        <span>実行環境を初期化中…</span>
+      </StatusBar>
+    );
+  }
   return (
     <StatusBar tone={blocked ? 'err' : 'ok'}>
       {blocked ? (
@@ -426,6 +471,18 @@ function RightPane({ rightMode, setRightMode, format, setFormat, enc, download, 
 
       <RightStatusBar rightMode={rightMode} enc={enc} blocked={blocked} r={r} />
     </section>
+  );
+}
+
+function InitializingOutput() {
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 14, background: 'var(--cg-bg-code)', padding: 32, textAlign: 'center' }}>
+      <span className="cg-spin" style={{ width: 34, height: 34, borderRadius: '50%', border: '3px solid var(--cg-border)', borderTopColor: 'var(--cg-red)', display: 'inline-block' }} />
+      <div style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-base)', fontWeight: 700, color: 'var(--cg-text)' }}>実行環境を初期化しています…</div>
+      <div style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)', color: 'var(--cg-text-muted)', maxWidth: 340, lineHeight: 1.6 }}>
+        ブラウザ上でPython実行環境（Pyodide）を読み込んでいます。初回は数秒かかることがあります。完了すると、ここに生成結果が表示されます。
+      </div>
+    </div>
   );
 }
 

--- a/web/src/components/EmptyState.tsx
+++ b/web/src/components/EmptyState.tsx
@@ -86,9 +86,9 @@ function ConceptCard({ icon, title, sub, note, outcome }: ConceptCardProps) {
   );
 }
 
-function Op({ children, accent }: { children: ReactNode; accent?: boolean }) {
+function Op({ children, accent, className }: { children: ReactNode; accent?: boolean; className?: string }) {
   return (
-    <div style={{ display: 'grid', placeItems: 'center', width: 34, flexShrink: 0, fontSize: 22, color: accent ? 'var(--cg-red)' : 'var(--cg-text-faint)', fontWeight: 700 }}>
+    <div className={className} style={{ display: 'grid', placeItems: 'center', width: 34, flexShrink: 0, fontSize: 22, color: accent ? 'var(--cg-red)' : 'var(--cg-text-faint)', fontWeight: 700 }}>
       {children}
     </div>
   );
@@ -196,11 +196,11 @@ export function EmptyState({
           </div>
 
           {/* concept diagram */}
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 4, marginBottom: 34, flexWrap: 'wrap' }}>
+          <div className="cg-concept" style={{ marginBottom: 34 }}>
             <ConceptCard icon={<Icon name="config-file" size={26} />} title="設定定義ファイル" sub="TOML · YAML · CSV" note="「値」を定義" />
             <Op>＋</Op>
             <ConceptCard icon={<Icon name="template-file" size={26} />} title="Jinjaテンプレート" sub=".j2 · .jinja2" note="「雛形」を記述" />
-            <Op accent>→</Op>
+            <Op accent className="cg-op-arrow">→</Op>
             <ConceptCard icon={<Icon name="terminal" size={26} color="var(--cg-red)" />} title="実行可能なコマンド" sub="CLI · Markdown" note="そのまま実行" outcome />
           </div>
 

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -25,9 +25,12 @@ html {
 
 /* ---- editor: Pyodide init spinner ---- */
 @keyframes cg-spin { to { transform: rotate(360deg); } }
+@keyframes cg-spin-pulse { 0%, 100% { opacity: 0.35; } 50% { opacity: 1; } }
 .cg-spin { animation: cg-spin 0.8s linear infinite; }
 @media (prefers-reduced-motion: reduce) {
-  .cg-spin { animation-duration: 2.4s; }
+  /* No rotation for motion-sensitive users; a gentle opacity pulse still
+     signals activity, consistent with this file's reduced-motion posture. */
+  .cg-spin { animation: cg-spin-pulse 1.6s ease-in-out infinite; }
 }
 
 /* ---- empty state: concept diagram ----

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -23,6 +23,28 @@ html {
   min-height: 100vh;
 }
 
+/* ---- editor: Pyodide init spinner ---- */
+@keyframes cg-spin { to { transform: rotate(360deg); } }
+.cg-spin { animation: cg-spin 0.8s linear infinite; }
+@media (prefers-reduced-motion: reduce) {
+  .cg-spin { animation-duration: 2.4s; }
+}
+
+/* ---- empty state: concept diagram ----
+   Row of three cards on desktop; when the viewport is too narrow to hold the
+   row, stack the cards vertically and point the flow arrow downward so the
+   "+" / "->" operators stay aligned instead of floating at wrapped row ends. */
+.cg-concept {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+@media (max-width: 720px) {
+  .cg-concept { flex-direction: column; }
+  .cg-concept .cg-op-arrow { transform: rotate(90deg); }
+}
+
 /* ---- tasteful, workplace-safe "haunting" for the empty state ---- */
 @keyframes cg-bob   { 0%,100% { transform: translateY(0) } 50% { transform: translateY(-9px) } }
 @keyframes cg-glow  { 0%,100% { opacity: .30; transform: scale(1) } 50% { opacity: .55; transform: scale(1.06) } }

--- a/web/src/useGenerate.ts
+++ b/web/src/useGenerate.ts
@@ -115,9 +115,13 @@ export function useGenerate(
     return () => clearTimeout(handle);
   }, [ready, memoKey, dataText, format, tplText, settings]);
 
-  // Shape the worker result into what the Editor consumes. `ready` reflects
-  // whether the Pyodide worker has finished bootstrapping: until then the
-  // right pane has no output to show and must render an initializing state
-  // rather than a blank/empty surface.
-  return useMemo<GenState>(() => ({ ...shapeResult(raw, dataText, format, tplText), ready }), [raw, tplText, dataText, format, ready]);
+  // Shape the worker result into what the Editor consumes. `ready` gates the
+  // output pane's loading state: the pane can show generated content only once
+  // the worker has bootstrapped AND the first result (or error) has actually
+  // arrived. Between the `ready` message and the first debounced generate
+  // result, `raw` is still null and shapeResult() returns an empty-but-"ok"
+  // value; without the `raw !== null` guard the pane would briefly render an
+  // empty result with copy/save enabled. A bootstrap error sets `raw` (so this
+  // becomes true) and surfaces via the normal error path rather than spinning.
+  return useMemo<GenState>(() => ({ ...shapeResult(raw, dataText, format, tplText), ready: ready && raw !== null }), [raw, tplText, dataText, format, ready]);
 }

--- a/web/src/useGenerate.ts
+++ b/web/src/useGenerate.ts
@@ -56,12 +56,14 @@ export function shapeResult(
   return { ok: true, error: null, suggest: null, vars, output: raw.output ?? "", json: raw.configDebug, interfaces, keys };
 }
 
+export type GenState = GenResult & { ready: boolean };
+
 export function useGenerate(
   dataText: string,
   format: Format,
   tplText: string,
   settings: GenerateSettings,
-): GenResult {
+): GenState {
   const workerRef = useRef<Worker | null>(null);
   const idRef = useRef(0);
   const [ready, setReady] = useState(false);
@@ -113,6 +115,9 @@ export function useGenerate(
     return () => clearTimeout(handle);
   }, [ready, memoKey, dataText, format, tplText, settings]);
 
-  // Shape the worker result into what the Editor consumes.
-  return useMemo<GenResult>(() => shapeResult(raw, dataText, format, tplText), [raw, tplText, dataText, format]);
+  // Shape the worker result into what the Editor consumes. `ready` reflects
+  // whether the Pyodide worker has finished bootstrapping: until then the
+  // right pane has no output to show and must render an initializing state
+  // rather than a blank/empty surface.
+  return useMemo<GenState>(() => ({ ...shapeResult(raw, dataText, format, tplText), ready }), [raw, tplText, dataText, format, ready]);
 }


### PR DESCRIPTION
## Summary

Four small, independent UX fixes on the Redesign B 2-pane editor (follow-up to
#441). Scope is `web/src` only; no engine or generation-behavior change.

Closes #529.

## Changes

1. **Pyodide "initializing" state (was: blank right pane).**
   `useGenerate` now exposes the worker `ready` flag. While the worker is
   bootstrapping, the output pane shows a spinner + explanation and the status
   bar shows "initializing", and copy/save are disabled. The spinner is shown
   only while genuinely loading: if the worker reports a bootstrap error,
   `blocked` is set and the existing error UI surfaces instead of an endless
   spinner.

2. **Draggable center splitter (was: fixed 50/50).**
   The bar between the panes now has a pointer-drag handler that reallocates the
   left/right width fraction, clamped to 20%-80% so neither pane collapses.

3. **Non-selectable editor chrome.**
   `user-select: none` on the app bar, pane headers, and status bars so they are
   clickable but do not drag-select as text.

4. **Empty-state concept diagram wrap.**
   Below a single-row width (media query at 720px) the three concept cards stack
   vertically and the flow arrow rotates to point downward, instead of the
   `+` / arrow operators floating at wrapped row ends.

## Verification

Driven end-to-end in Chromium (Playwright) against the dev server, plus
`tsc -b` and the Vitest UI suite:

- Init state: spinner + "initializing" text render; copy button `disabled=true`
  while the Pyodide fetch is stalled.
- Splitter: dragging the separator +260px grew the left pane 717px -> 975px.
- Chrome: computed `user-select` on the app bar header is `none`.
- Concept diagram: `flex-direction` is `column` + arrow rotated at 600px, and
  `row` + no rotation at 900px.
- No horizontal overflow on the empty state across 360-2560px.

`tsc -b` passes; UI tests pass. The only failing test is
`pyodide-runtime.node.test.ts`, which fails in this environment because the
Pyodide wheels are not vendored (offline) - unrelated to this change.

## Notes

- Refs #441 (parent Redesign B migration).
- Side effect of (2): dragging a pane very narrow clips its header buttons; they
  return on dragging back. Making the header collapsible is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AnNqAtPC31wodDZmYiRgz4)_