### PR TITLE
feat(web): editor UX enhancements round 2 (#532)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -56,6 +56,7 @@ function uploadedTemplate(config: UploadedPart, template: UploadedPart): Templat
     name: `${config.file.name} + ${template.file.name}`,
     desc: "アップロードした2つのファイルから作成した一時ドキュメント。",
     category: "network",
+    subCategory: "アップロード",
     format: formatFromFileName(config.file.name),
     output: "markdown",
     updated: new Date().toISOString().slice(0, 10),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -41,7 +41,7 @@ function analyticsLocation(): { route: string; path: string } {
   return { route: "/", path: "/" };
 }
 
-const DEFAULT_DOWNLOAD: DownloadOptions = { enc: "UTF-8", fname: "command", ts: true, ext: "txt" };
+const DEFAULT_DOWNLOAD: DownloadOptions = { enc: "UTF-8", ts: true };
 
 function formatFromFileName(name: string): Format {
   const ext = name.split(".").pop()?.toLowerCase();

--- a/web/src/components/Editor.test.tsx
+++ b/web/src/components/Editor.test.tsx
@@ -2,7 +2,7 @@
 // NOTE: These tests replaced the old textarea-based Editor tests (stale after P2 redesign port).
 // The new Editor is the full two-pane Pyodide-backed editor; smoke-test that it mounts.
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
 
 // jsdom has no real Worker; mock the worker module so useGenerate's mount doesn't crash.
 // The mock records each constructed instance so a test can drive its onmessage handler
@@ -22,7 +22,7 @@ vi.mock("../worker/generate.worker?worker", () => ({
 import { Editor } from "./Editor";
 import { DEFAULT_SETTINGS } from "../worker/types";
 
-const defaultDownload = { enc: "UTF-8" as const, fname: "output", ts: false, ext: "txt" };
+const defaultDownload = { enc: "UTF-8" as const, ts: false };
 
 function renderEditor() {
   return render(
@@ -85,5 +85,30 @@ describe("Editor (redesign-b)", () => {
     expect(screen.queryByText("実行環境を初期化しています…")).toBeNull();
     expect(screen.getByText("HELLO WORLD")).toBeTruthy();
     expect((screen.getByRole("button", { name: "コピー" }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("downloads with the editable filename and a mode-derived extension", () => {
+    vi.useFakeTimers();
+    renderEditor();
+    const worker = workerInstances[0];
+    act(() => { worker.onmessage!({ data: { kind: "ready" } } as MessageEvent); });
+    act(() => { vi.advanceTimersByTime(300); });
+    act(() => {
+      worker.onmessage!({
+        data: { kind: "result", id: 1, result: { output: "OUT\n", configError: null, templateError: null, configDebug: "{}" } },
+      } as MessageEvent);
+    });
+
+    // Default doc name is "command"; 手順書 (md) mode → .md in the footer save button.
+    expect(screen.getByRole("button", { name: /command\.md を保存/ })).toBeTruthy();
+
+    // Editing the header filename flows into the download name.
+    const nameInput = screen.getByLabelText("ファイル名") as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "myrunbook" } });
+    expect(screen.getByRole("button", { name: /myrunbook\.md を保存/ })).toBeTruthy();
+
+    // Raw output mode switches the extension to .txt.
+    fireEvent.click(screen.getByRole("button", { name: "Raw" }));
+    expect(screen.getByRole("button", { name: /myrunbook\.txt を保存/ })).toBeTruthy();
   });
 });

--- a/web/src/components/Editor.test.tsx
+++ b/web/src/components/Editor.test.tsx
@@ -110,5 +110,36 @@ describe("Editor (redesign-b)", () => {
     // Raw output mode switches the extension to .txt.
     fireEvent.click(screen.getByRole("button", { name: "Raw" }));
     expect(screen.getByRole("button", { name: /myrunbook\.txt を保存/ })).toBeTruthy();
+
+    // Filename-invalid characters are stripped from the download name.
+    fireEvent.change(nameInput, { target: { value: "a/b:c*" } });
+    expect(screen.getByRole("button", { name: /abc\.txt を保存/ })).toBeTruthy();
+
+    // Clearing the field falls back to the default "command" base.
+    fireEvent.change(nameInput, { target: { value: "" } });
+    expect(screen.getByRole("button", { name: /command\.txt を保存/ })).toBeTruthy();
+  });
+
+  it("notes the timestamp suffix in the save label when enabled", () => {
+    vi.useFakeTimers();
+    render(
+      <Editor
+        settings={DEFAULT_SETTINGS}
+        onSettings={() => {}}
+        download={{ enc: "UTF-8", ts: true }}
+        onDownload={() => {}}
+      />,
+    );
+    const worker = workerInstances[0];
+    act(() => { worker.onmessage!({ data: { kind: "ready" } } as MessageEvent); });
+    act(() => { vi.advanceTimersByTime(300); });
+    act(() => {
+      worker.onmessage!({
+        data: { kind: "result", id: 1, result: { output: "X\n", configError: null, templateError: null, configDebug: "{}" } },
+      } as MessageEvent);
+    });
+    // With the timestamp toggle on, the label must disclose the suffix rather
+    // than claim the plain "command.md" name.
+    expect(screen.getByRole("button", { name: /command\.md（\+日時） を保存/ })).toBeTruthy();
   });
 });

--- a/web/src/components/Editor.tsx
+++ b/web/src/components/Editor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { ReactNode } from 'react';
-import { Button, Badge, Selectbox } from '../ds';
+import { Button, Badge } from '../ds';
 import { CodeView } from './CodeView';
 import { SettingsModal } from './SettingsModal';
 import type { DownloadOptions } from './SettingsModal';
@@ -99,6 +99,13 @@ function computeDataErrLine(r: GenResult): number {
   return r.error && r.error.pane !== 'tpl' ? r.error.line || 0 : 0;
 }
 
+// Minimum widths (px) each pane keeps while dragging the splitter, so header
+// controls never clip. The left header (data/template tabs + format switch) is
+// wider than the right (output tabs + copy), so the two sides get different
+// floors — measured against the widest state of each header.
+const LEFT_MIN_PX = 512;
+const RIGHT_MIN_PX = 448;
+
 export function Editor({ initial, onBack, settings, onSettings, download, onDownload }: EditorProps) {
   const tpl = initial || null;
   const [leftTab, setLeftTab] = React.useState<'data' | 'tpl'>('data');
@@ -111,6 +118,8 @@ export function Editor({ initial, onBack, settings, onSettings, download, onDown
   // live, editable input
   const [dataText, setDataText] = React.useState(initialData(tpl));
   const [tplText, setTplText] = React.useState(initialTemplate(tpl));
+  // Editable document name shown in the app bar; it is the download filename base.
+  const [docName, setDocName] = React.useState(tpl?.id || 'command');
 
   const toastTimer = React.useRef<ReturnType<typeof setTimeout>>();
   const fire = (msg: string) => {
@@ -123,7 +132,6 @@ export function Editor({ initial, onBack, settings, onSettings, download, onDown
   const r = useGenerate(dataText, format, tplText, settings);
   const blocked = !r.ok;
   const dataErrLine = computeDataErrLine(r);
-  const enc = download.enc;
 
   // Draggable split between the two panes. `leftFrac` is the committed left-pane
   // width fraction (clamped so neither pane collapses). During a drag we mutate
@@ -152,7 +160,13 @@ export function Editor({ initial, onBack, settings, onSettings, download, onDown
     let raf = 0;
     const onMove = (ev: PointerEvent) => {
       const rect = ws.getBoundingClientRect();
-      frac = Math.min(0.8, Math.max(0.2, (ev.clientX - rect.left) / rect.width));
+      // Clamp so neither pane header clips: left floor is LEFT_MIN_PX, right
+      // floor is RIGHT_MIN_PX. When the window is too small to grant both
+      // floors, fall back to a 50/50 split.
+      const minFrac = LEFT_MIN_PX / rect.width;
+      const maxFrac = 1 - RIGHT_MIN_PX / rect.width;
+      const raw = (ev.clientX - rect.left) / rect.width;
+      frac = minFrac < maxFrac ? Math.min(maxFrac, Math.max(minFrac, raw)) : 0.5;
       if (!raf) raf = requestAnimationFrame(() => { raf = 0; ws.style.gridTemplateColumns = `${frac}fr 7px ${1 - frac}fr`; });
     };
     const teardown = () => {
@@ -177,7 +191,7 @@ export function Editor({ initial, onBack, settings, onSettings, download, onDown
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', minHeight: 620, minWidth: 1024, background: 'var(--cg-bg)', fontFamily: 'var(--font-sans)', color: 'var(--cg-text)' }}>
 
       {/* ===== App bar ===== */}
-      <AppBar tpl={tpl} blocked={blocked} onBack={onBack} onHowto={() => setHowto(true)} onSettings={() => setSettingsOpen(true)} />
+      <AppBar tpl={tpl} blocked={blocked} docName={docName} setDocName={setDocName} onBack={onBack} onHowto={() => setHowto(true)} onSettings={() => setSettingsOpen(true)} />
 
       {/* ===== Workspace ===== */}
       <div ref={workspaceRef} style={{ flex: 1, display: 'grid', gridTemplateRows: 'minmax(0, 1fr)', minHeight: 0 }}>
@@ -214,9 +228,8 @@ export function Editor({ initial, onBack, settings, onSettings, download, onDown
           setRightMode={setRightMode}
           format={format}
           setFormat={setFormat}
-          enc={enc}
           download={download}
-          onDownload={onDownload}
+          docName={docName}
           blocked={blocked}
           r={r}
           fire={fire}
@@ -249,7 +262,7 @@ const FORMATS: SegItem[] = [
 
 type GenResult = ReturnType<typeof useGenerate>;
 
-function AppBar({ tpl, blocked, onBack, onHowto, onSettings }: { tpl: Template | null; blocked: boolean; onBack?: () => void; onHowto: () => void; onSettings: () => void }) {
+function AppBar({ tpl, blocked, docName, setDocName, onBack, onHowto, onSettings }: { tpl: Template | null; blocked: boolean; docName: string; setDocName: (v: string) => void; onBack?: () => void; onHowto: () => void; onSettings: () => void }) {
   return (
     <header style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-4)', padding: '0 18px', height: 56, borderBottom: '1px solid var(--cg-border)', flexShrink: 0, userSelect: 'none' }}>
       {onBack && (
@@ -261,7 +274,16 @@ function AppBar({ tpl, blocked, onBack, onHowto, onSettings }: { tpl: Template |
       </div>
       <div style={{ width: 1, height: 22, background: 'var(--cg-border)', margin: '0 4px' }} />
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: 'var(--cg-text-muted)', fontSize: 'var(--text-sm)' }}>
-        <span style={{ color: 'var(--cg-text)' }}>{tpl ? tpl.id : '無題のドキュメント'}</span>
+        <input
+          className="cg-fname"
+          value={docName}
+          onChange={(e) => setDocName(e.target.value)}
+          size={Math.max(docName.length || 1, 4)}
+          spellCheck={false}
+          aria-label="ファイル名"
+          title="ファイル名（ダウンロード名に使われます）"
+          style={{ color: 'var(--cg-text)', fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)', fontWeight: 600, background: 'transparent', borderRadius: 'var(--radius-sm)', padding: '3px 7px', outline: 'none', minWidth: 40, maxWidth: 280 }}
+        />
         <Badge tone="success">{tpl ? '保存済み' : '新規'}</Badge>
       </div>
       <div style={{ flex: 1 }} />
@@ -395,18 +417,16 @@ function LeftPane({ leftTab, setLeftTab, format, setFormat, dataText, setDataTex
   );
 }
 
-function OutputActions({ enc, download, onDownload, blocked, r, fire }: { enc: DownloadOptions['enc']; download: DownloadOptions; onDownload: (d: DownloadOptions) => void; blocked: boolean; r: GenResult; fire: (msg: string) => void }) {
+// Copy stays in the pane header; the download action lives in the footer.
+function CopyButton({ blocked, r, fire }: { blocked: boolean; r: GenResult; fire: (msg: string) => void }) {
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-      <Selectbox value={enc} options={['UTF-8', 'Shift_JIS']} onChange={(v) => onDownload({ ...download, enc: v as DownloadOptions['enc'] })} style={{ width: 152 }} />
-      <Button variant="secondary" size="sm" disabled={blocked || !r.ready} icon={<Icon name="copy" size={14} />} onClick={() => { void navigator.clipboard.writeText(r.output); fire('コピーしました'); }}>コピー</Button>
-      <Button variant="primary" size="sm" disabled={blocked || !r.ready} icon={<Icon name="download" size={14} />} onClick={() => {
-        const e: DownloadEncoding = enc === 'Shift_JIS' ? 'Shift_JIS' : 'utf-8';
-        triggerDownload(r.output, downloadFilename(download.fname, download.ext, download.ts), e);
-        fire('ダウンロードを開始');
-      }}>保存</Button>
-    </div>
+    <Button variant="secondary" size="sm" disabled={blocked || !r.ready} icon={<Icon name="copy" size={14} />} onClick={() => { void navigator.clipboard.writeText(r.output); fire('コピーしました'); }}>コピー</Button>
   );
+}
+
+// Extension is derived from the output mode: 手順書 (md) → .md, Raw → .txt.
+function outputExt(rightMode: 'md' | 'raw' | 'debug'): string {
+  return rightMode === 'md' ? 'md' : 'txt';
 }
 
 function OutputBody({ rightMode, format, setFormat, blocked, r }: { rightMode: 'md' | 'raw' | 'debug'; format: Format; setFormat: (f: Format) => void; blocked: boolean; r: GenResult }) {
@@ -428,7 +448,7 @@ function OutputBody({ rightMode, format, setFormat, blocked, r }: { rightMode: '
   );
 }
 
-function RightStatusBar({ rightMode, enc, blocked, r }: { rightMode: 'md' | 'raw' | 'debug'; enc: DownloadOptions['enc']; blocked: boolean; r: GenResult }) {
+function RightStatusBar({ rightMode, download, docName, blocked, r, fire }: { rightMode: 'md' | 'raw' | 'debug'; download: DownloadOptions; docName: string; blocked: boolean; r: GenResult; fire: (msg: string) => void }) {
   if (!r.ready && !blocked) {
     return (
       <StatusBar>
@@ -437,6 +457,13 @@ function RightStatusBar({ rightMode, enc, blocked, r }: { rightMode: 'md' | 'raw
       </StatusBar>
     );
   }
+  const ext = outputExt(rightMode);
+  const filename = `${docName.trim() || 'command'}.${ext}`;
+  const onSave = () => {
+    const e: DownloadEncoding = download.enc === 'Shift_JIS' ? 'Shift_JIS' : 'utf-8';
+    triggerDownload(r.output, downloadFilename(docName.trim() || 'command', ext, download.ts), e);
+    fire('ダウンロードを開始');
+  };
   return (
     <StatusBar tone={blocked ? 'err' : 'ok'}>
       {blocked ? (
@@ -448,8 +475,16 @@ function RightStatusBar({ rightMode, enc, blocked, r }: { rightMode: 'md' | 'raw
         <>
           <span>✓</span>
           {rightMode === 'raw' && <span>生成成功 · {r.output.replace(/\n+$/, '').split('\n').length} 行 · raw</span>}
-          {rightMode === 'md' && <span>手順書を生成 · {enc}</span>}
+          {rightMode === 'md' && <span>手順書を生成 · {download.enc}</span>}
           {rightMode === 'debug' && <span>解析成功 · {r.keys} keys · {r.interfaces} interfaces</span>}
+        </>
+      )}
+      {rightMode !== 'debug' && (
+        <>
+          <div style={{ flex: 1 }} />
+          <Button variant="primary" size="sm" disabled={blocked || !r.ready} icon={<Icon name="download" size={13} />} title={`${filename} をダウンロード`} onClick={onSave}>
+            {filename} を保存
+          </Button>
         </>
       )}
     </StatusBar>
@@ -461,15 +496,14 @@ interface RightPaneProps {
   setRightMode: (m: 'md' | 'raw' | 'debug') => void;
   format: Format;
   setFormat: (f: Format) => void;
-  enc: DownloadOptions['enc'];
   download: DownloadOptions;
-  onDownload: (d: DownloadOptions) => void;
+  docName: string;
   blocked: boolean;
   r: GenResult;
   fire: (msg: string) => void;
 }
 
-function RightPane({ rightMode, setRightMode, format, setFormat, enc, download, onDownload, blocked, r, fire }: RightPaneProps) {
+function RightPane({ rightMode, setRightMode, format, setFormat, download, docName, blocked, r, fire }: RightPaneProps) {
   return (
     <section style={{ display: 'flex', flexDirection: 'column', minWidth: 0, minHeight: 0, overflow: 'hidden' }}>
       <PaneHeader>
@@ -483,16 +517,14 @@ function RightPane({ rightMode, setRightMode, format, setFormat, enc, download, 
           ]}
         />
         <div style={{ flex: 1 }} />
-        {rightMode !== 'debug' && (
-          <OutputActions enc={enc} download={download} onDownload={onDownload} blocked={blocked} r={r} fire={fire} />
-        )}
+        {rightMode !== 'debug' && <CopyButton blocked={blocked} r={r} fire={fire} />}
       </PaneHeader>
 
       <div style={{ flex: 1, minHeight: 0 }}>
         <OutputBody rightMode={rightMode} format={format} setFormat={setFormat} blocked={blocked} r={r} />
       </div>
 
-      <RightStatusBar rightMode={rightMode} enc={enc} blocked={blocked} r={r} />
+      <RightStatusBar rightMode={rightMode} download={download} docName={docName} blocked={blocked} r={r} fire={fire} />
     </section>
   );
 }

--- a/web/src/components/Editor.tsx
+++ b/web/src/components/Editor.tsx
@@ -12,7 +12,7 @@ import type { GenerateSettings } from '../worker/types';
 import type { Template } from '../lib/types';
 import { useGenerate } from '../useGenerate';
 import type { GenError } from '../useGenerate';
-import { triggerDownload, downloadFilename } from '../download';
+import { triggerDownload, downloadFilename, sanitizeFilename } from '../download';
 import type { DownloadEncoding } from '../download';
 import logoMark from '../assets/brand/logo-mark.svg';
 
@@ -151,6 +151,22 @@ export function Editor({ initial, onBack, settings, onSettings, download, onDown
   // Tear down an in-flight drag if the editor unmounts before pointer-up, so the
   // window listeners and the global body cursor/user-select don't leak.
   React.useEffect(() => () => dragCleanupRef.current?.(), []);
+  // Re-clamp the committed split on window resize. The floors are pixel-based
+  // but `leftFrac` is stored as a fraction re-applied in fr units, so without
+  // this a "drag wide, then shrink the window" sequence would drop a pane below
+  // its floor and clip its header — exactly what the floors exist to prevent.
+  React.useEffect(() => {
+    const onResize = () => {
+      const ws = workspaceRef.current;
+      if (!ws) return;
+      const w = ws.getBoundingClientRect().width;
+      const minFrac = LEFT_MIN_PX / w;
+      const maxFrac = 1 - RIGHT_MIN_PX / w;
+      setLeftFrac((f) => (minFrac < maxFrac ? Math.min(maxFrac, Math.max(minFrac, f)) : 0.5));
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
 
   const startResize = (e: React.PointerEvent) => {
     e.preventDefault();
@@ -278,7 +294,9 @@ function AppBar({ tpl, blocked, docName, setDocName, onBack, onHowto, onSettings
           className="cg-fname"
           value={docName}
           onChange={(e) => setDocName(e.target.value)}
-          size={Math.max(docName.length || 1, 4)}
+          size={Math.max(docName.length, 7)}
+          maxLength={80}
+          placeholder="command"
           spellCheck={false}
           aria-label="ファイル名"
           title="ファイル名（ダウンロード名に使われます）"
@@ -458,10 +476,16 @@ function RightStatusBar({ rightMode, download, docName, blocked, r, fire }: { ri
     );
   }
   const ext = outputExt(rightMode);
-  const filename = `${docName.trim() || 'command'}.${ext}`;
+  // Sanitize once and reuse for the label, the tooltip, and the actual download
+  // so they can't diverge. The label notes the timestamp suffix (rather than
+  // rendering a concrete time that would drift from the click-time value) and
+  // truncates a long base so it can't overflow the footer.
+  const base = sanitizeFilename(docName) || 'command';
+  const tsNote = download.ts ? '（+日時）' : '';
+  const dispBase = base.length > 32 ? base.slice(0, 31) + '…' : base;
   const onSave = () => {
     const e: DownloadEncoding = download.enc === 'Shift_JIS' ? 'Shift_JIS' : 'utf-8';
-    triggerDownload(r.output, downloadFilename(docName.trim() || 'command', ext, download.ts), e);
+    triggerDownload(r.output, downloadFilename(base, ext, download.ts), e);
     fire('ダウンロードを開始');
   };
   return (
@@ -482,8 +506,8 @@ function RightStatusBar({ rightMode, download, docName, blocked, r, fire }: { ri
       {rightMode !== 'debug' && (
         <>
           <div style={{ flex: 1 }} />
-          <Button variant="primary" size="sm" disabled={blocked || !r.ready} icon={<Icon name="download" size={13} />} title={`${filename} をダウンロード`} onClick={onSave}>
-            {filename} を保存
+          <Button variant="primary" size="sm" disabled={blocked || !r.ready} icon={<Icon name="download" size={13} />} title={`${base}.${ext}${tsNote} をダウンロード`} onClick={onSave}>
+            {dispBase}.{ext}{tsNote} を保存
           </Button>
         </>
       )}

--- a/web/src/components/EmptyState.tsx
+++ b/web/src/components/EmptyState.tsx
@@ -169,7 +169,7 @@ export function EmptyState({
 
       {/* hero */}
       <div style={{ flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'flex-start', padding: '40px 24px', position: 'relative', zIndex: 1 }}>
-        <div style={{ width: '100%', maxWidth: 880 }}>
+        <div className="cg-enter-up" style={{ width: '100%', maxWidth: 880 }}>
 
           {/* headline */}
           <div style={{ textAlign: 'center', marginBottom: 30 }}>
@@ -190,8 +190,8 @@ export function EmptyState({
               <span style={{ fontFamily: 'var(--font-mono)', fontSize: 13, color: 'var(--cg-red)', fontWeight: 600 }}>&gt;_</span>
               <span style={{ width: 40, height: 1, background: 'linear-gradient(90deg, var(--cg-border-strong), transparent)' }} />
             </div>
-            <div className="cg-flicker" style={{ fontFamily: 'var(--font-mono)', fontSize: 'var(--text-sm)', letterSpacing: '.18em', color: 'var(--cg-ghost-outline)' }}>
-              設定定義 × テンプレート → 再現可能なコマンド
+            <div className="cg-flicker" style={{ fontFamily: 'var(--font-mono)', fontSize: 'var(--text-sm)', letterSpacing: '.14em', color: 'var(--cg-ghost-outline)' }}>
+              値を変えるだけで、コマンドも手順書も。
             </div>
           </div>
 

--- a/web/src/components/HowToModal.tsx
+++ b/web/src/components/HowToModal.tsx
@@ -49,8 +49,8 @@ function Step({ n, title, children }: { n: number; title: string; children: Reac
 export function HowToModal({ open, onClose }: HowToModalProps) {
   if (!open) return null;
   return (
-    <div onClick={onClose} style={{ position: "fixed", inset: 0, zIndex: 1000, background: "rgba(0,0,0,.55)", backdropFilter: "blur(2px)", display: "grid", placeItems: "center", padding: 24 }}>
-      <div onClick={(e) => e.stopPropagation()} style={{ width: 680, maxHeight: "88vh", overflow: "auto", background: "var(--cg-bg)", border: "1px solid var(--cg-border)", borderRadius: "var(--radius-lg)", boxShadow: "var(--shadow-lg)", fontFamily: "var(--font-sans)", color: "var(--cg-text)" }}>
+    <div className="cg-overlay-in" onClick={onClose} style={{ position: "fixed", inset: 0, zIndex: 1000, background: "rgba(0,0,0,.55)", backdropFilter: "blur(2px)", display: "grid", placeItems: "center", padding: 24 }}>
+      <div className="cg-pop-in" onClick={(e) => e.stopPropagation()} style={{ width: 680, maxHeight: "88vh", overflow: "auto", background: "var(--cg-bg)", border: "1px solid var(--cg-border)", borderRadius: "var(--radius-lg)", boxShadow: "var(--shadow-lg)", fontFamily: "var(--font-sans)", color: "var(--cg-text)" }}>
 
         {/* header */}
         <div style={{ position: "sticky", top: 0, zIndex: 1, display: "flex", alignItems: "center", justifyContent: "space-between", padding: "16px 20px", borderBottom: "1px solid var(--cg-border)", background: "var(--cg-bg)" }}>

--- a/web/src/components/Library.tsx
+++ b/web/src/components/Library.tsx
@@ -20,6 +20,26 @@ const CATS: { id: TemplateCategory | 'all'; label: string; icon: string }[] = [
 const FMT_TONE: Record<Format, 'brand' | 'info' | 'warning'> = { toml: 'brand', yaml: 'info', csv: 'warning' };
 const OUT_LABEL: Record<TemplateOutput, string> = { cli: 'CLI', config: 'config', markdown: 'Markdown' };
 
+const CAT_ORDER = CATS.map((c) => c.id);
+
+// Group templates into ordered sub-category sections. Groups are ordered by
+// their category (so same-category sub-categories stay adjacent, even in the
+// "すべて" view) and, within that, by first appearance; template order inside a
+// group is preserved.
+function groupBySubCategory(list: Template[]): { label: string; items: Template[] }[] {
+  const sorted = [...list].sort((a, b) => CAT_ORDER.indexOf(a.category) - CAT_ORDER.indexOf(b.category));
+  const groups: { label: string; items: Template[] }[] = [];
+  for (const t of sorted) {
+    let g = groups.find((x) => x.label === t.subCategory);
+    if (!g) {
+      g = { label: t.subCategory, items: [] };
+      groups.push(g);
+    }
+    g.items.push(t);
+  }
+  return groups;
+}
+
 function CatIcon({ name, size, color }: { name: string; size: number; color?: string }) {
   return <Icon name={name} size={size} color={color} />;
 }
@@ -75,6 +95,7 @@ export function Library({ onOpen, onClose }: LibraryProps) {
   const [cat, setCat] = React.useState<TemplateCategory | 'all'>('all');
   const all = CGTemplates;
   const list = cat === 'all' ? all : all.filter((t) => t.category === cat);
+  const groups = groupBySubCategory(list);
   const count = (id: TemplateCategory | 'all') => (id === 'all' ? all.length : all.filter((t) => t.category === id).length);
 
   return (
@@ -135,8 +156,8 @@ export function Library({ onOpen, onClose }: LibraryProps) {
           <p style={{ fontSize: 'var(--text-sm)', color: 'var(--cg-text-muted)', margin: '0 0 22px' }}>
             定型作業のテンプレートを選ぶと、データ定義とテンプレートを読み込んだ状態でエディタが開きます。
           </p>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(244px, 1fr))', gap: 14 }}>
-            {/* 空から作成 */}
+          {/* 空から作成 */}
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(244px, 1fr))', gap: 14, marginBottom: 28 }}>
             <button
               onClick={() => onOpen(null)}
               style={{
@@ -158,10 +179,22 @@ export function Library({ onOpen, onClose }: LibraryProps) {
               <span style={{ fontSize: 'var(--text-sm)', fontWeight: 600 }}>空から作成</span>
               <span style={{ fontSize: 'var(--text-xs)', color: 'var(--cg-text-faint)' }}>サンプルから書き始める</span>
             </button>
-            {list.map((t) => (
-              <TemplateCard key={t.id} tpl={t} onOpen={onOpen} />
-            ))}
           </div>
+
+          {/* sub-category sections */}
+          {groups.map((g) => (
+            <section key={g.label} style={{ marginBottom: 26 }}>
+              <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, margin: '0 0 12px', paddingBottom: 6, borderBottom: '1px solid var(--cg-border)' }}>
+                <span style={{ fontSize: 'var(--text-sm)', fontWeight: 700, color: 'var(--cg-text)' }}>{g.label}</span>
+                <span style={{ fontSize: 11, color: 'var(--cg-text-faint)', fontFamily: 'var(--font-mono)' }}>{g.items.length}</span>
+              </div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(244px, 1fr))', gap: 14 }}>
+                {g.items.map((t) => (
+                  <TemplateCard key={t.id} tpl={t} onOpen={onOpen} />
+                ))}
+              </div>
+            </section>
+          ))}
         </main>
       </div>
     </div>

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Toggle, TextInput, Selectbox, RadioGroup, Button } from '../ds';
+import { Toggle, TextInput, Selectbox, Button } from '../ds';
 import { Icon } from './Icon';
 import type { GenerateSettings } from '../worker/types';
 
@@ -28,9 +28,7 @@ function Sub({ children }: { children: React.ReactNode }) {
 
 export interface DownloadOptions {
   enc: 'UTF-8' | 'Shift_JIS';
-  fname: string;
   ts: boolean;
-  ext: string;
 }
 
 export interface SettingsModalProps {
@@ -52,6 +50,7 @@ export function SettingsModal({ open, onClose, settings, onSettings, download, o
 
   return (
     <div
+      className="cg-overlay-in"
       onClick={onClose}
       style={{
         position: 'fixed',
@@ -65,6 +64,7 @@ export function SettingsModal({ open, onClose, settings, onSettings, download, o
       }}
     >
       <div
+        className="cg-pop-in"
         onClick={(e) => e.stopPropagation()}
         style={{
           width: 620,
@@ -140,28 +140,15 @@ export function SettingsModal({ open, onClose, settings, onSettings, download, o
               />
             </Field>
             <Field>
-              <TextInput
-                label="ダウンロード時のファイル名"
-                value={download.fname}
-                onChange={(v) => setD({ fname: v })}
-              />
-            </Field>
-            <Field>
               <Toggle
                 checked={download.ts}
                 label="ファイル名にタイムスタンプを付与"
                 onChange={(v) => setD({ ts: v })}
               />
             </Field>
-            <Field>
-              <RadioGroup
-                label="ファイル拡張子"
-                value={download.ext}
-                options={['txt', 'md']}
-                horizontal
-                onChange={(v) => setD({ ext: v })}
-              />
-            </Field>
+            <div style={{ fontSize: 'var(--text-xs)', color: 'var(--cg-text-faint)', lineHeight: 1.6 }}>
+              ファイル名はエディタ上部で編集できます。拡張子は出力（手順書 → .md / Raw → .txt）に応じて自動で決まります。
+            </div>
           </div>
         </div>
 

--- a/web/src/download.ts
+++ b/web/src/download.ts
@@ -12,6 +12,14 @@ export function downloadFilename(name: string, ext: string, appendTimestamp: boo
   return `${name}${suffix}.${ext}`;
 }
 
+// Strip characters that are invalid in filenames across OSes (path separators
+// and Windows-reserved punctuation) plus leading dots, so a user-typed document
+// name can't produce a broken or platform-dependent download name. Returns ""
+// when nothing usable remains, so callers supply a fallback base.
+export function sanitizeFilename(name: string): string {
+  return name.replace(/[/\\:*?"<>|]/g, "").replace(/^\.+/, "").trim();
+}
+
 export function encodeText(text: string, encoding: DownloadEncoding): BlobPart {
   if (encoding === "Shift_JIS") {
     const codes = Encoding.stringToCode(text);

--- a/web/src/lib/templates.ts
+++ b/web/src/lib/templates.ts
@@ -18,6 +18,7 @@ interface Meta {
   name: string;
   desc: string;
   category: TemplateCategory;
+  subCategory: string;
   format: Format;
   output: TemplateOutput;
   updated: string;
@@ -25,15 +26,15 @@ interface Meta {
 }
 
 const META: Meta[] = [
-  { id: "cisco-switchport", name: "Cisco スイッチポート設定", desc: "インターフェースの mode / VLAN / description から、CLI を含む設定手順書（Markdown）を生成。", category: "network", format: "toml", output: "markdown", updated: "2026-06-28", live: true },
-  { id: "yamaha-router", name: "YAMAHA ルータ初期構築", desc: "RTX系ルータの LAN / PPPoE / IPフィルタ / NAT 設定を、CLI を含む手順書（Markdown）として生成。", category: "network", format: "toml", output: "markdown", updated: "2026-06-25", live: true },
-  { id: "linux-init", name: "Linux 初期セットアップ", desc: "ホスト名・ユーザー・SSH・タイムゾーン・パッケージ・ufw の初期化を、CLI を含む手順書（Markdown）として生成。", category: "server", format: "yaml", output: "markdown", updated: "2026-06-22", live: true },
-  { id: "dns-zone", name: "DNS ゾーンファイル初期化", desc: "$ORIGIN / $TTL / SOA / NS / MX / A / 各種 TXT を含むゾーンを、登録・反映手順書（Markdown）として生成。", category: "dns", format: "toml", output: "markdown", updated: "2026-06-30", live: true },
-  { id: "incident-campus", name: "キャンパスネットワーク障害対応", desc: "症状・影響範囲・切り分けステップ・エスカレーションから Markdown 手順書を生成。", category: "runbook", format: "yaml", output: "markdown", updated: "2026-06-18", live: true },
-  { id: "incident-proxy", name: "プロキシ環境のWebサービス接続不能", desc: "プロキシ設定・確認コマンド・判断分岐から Markdown 切り分け手順書を生成。", category: "runbook", format: "yaml", output: "markdown", updated: "2026-06-15", live: true },
-  { id: "firewall-rules", name: "firewalld ルール一括投入", desc: "CSV の 1 行 1 ルールから、Rocky Linux 標準の firewalld rich rule 投入手順書（Markdown）を生成。", category: "network", format: "csv", output: "markdown", updated: "2026-06-30", live: true },
-  { id: "dgx-spark-ollama", name: "DGX Spark + ollama 初期構築", desc: "DGX OS の初期設定・SSH 堅牢化・ufw から、ollama の LAN 内 API 公開・モデル取得までの手順書（Markdown）を生成。", category: "ai", format: "yaml", output: "markdown", updated: "2026-07-02", live: true },
-  { id: "zero-trust-access", name: "ゼロトラストアクセス基盤構築", desc: "step-ca + Caddy の mTLS で AI マシンの API / SSH を保護する、商用利用可能な OSS 構成の構築手順書（Markdown）を生成。", category: "ai", format: "yaml", output: "markdown", updated: "2026-07-02", live: true },
+  { id: "cisco-switchport", name: "Cisco スイッチポート設定", desc: "インターフェースの mode / VLAN / description から、CLI を含む設定手順書（Markdown）を生成。", category: "network", subCategory: "Cisco", format: "toml", output: "markdown", updated: "2026-06-28", live: true },
+  { id: "yamaha-router", name: "YAMAHA ルータ初期構築", desc: "RTX系ルータの LAN / PPPoE / IPフィルタ / NAT 設定を、CLI を含む手順書（Markdown）として生成。", category: "network", subCategory: "YAMAHA", format: "toml", output: "markdown", updated: "2026-06-25", live: true },
+  { id: "linux-init", name: "Linux 初期セットアップ", desc: "ホスト名・ユーザー・SSH・タイムゾーン・パッケージ・ufw の初期化を、CLI を含む手順書（Markdown）として生成。", category: "server", subCategory: "Ubuntu / Debian", format: "yaml", output: "markdown", updated: "2026-06-22", live: true },
+  { id: "dns-zone", name: "DNS ゾーンファイル初期化", desc: "$ORIGIN / $TTL / SOA / NS / MX / A / 各種 TXT を含むゾーンを、登録・反映手順書（Markdown）として生成。", category: "dns", subCategory: "BIND", format: "toml", output: "markdown", updated: "2026-06-30", live: true },
+  { id: "incident-campus", name: "キャンパスネットワーク障害対応", desc: "症状・影響範囲・切り分けステップ・エスカレーションから Markdown 手順書を生成。", category: "runbook", subCategory: "ネットワーク", format: "yaml", output: "markdown", updated: "2026-06-18", live: true },
+  { id: "incident-proxy", name: "プロキシ環境のWebサービス接続不能", desc: "プロキシ設定・確認コマンド・判断分岐から Markdown 切り分け手順書を生成。", category: "runbook", subCategory: "プロキシ / Web", format: "yaml", output: "markdown", updated: "2026-06-15", live: true },
+  { id: "firewall-rules", name: "firewalld ルール一括投入", desc: "CSV の 1 行 1 ルールから、Rocky Linux 標準の firewalld rich rule 投入手順書（Markdown）を生成。", category: "network", subCategory: "firewalld", format: "csv", output: "markdown", updated: "2026-06-30", live: true },
+  { id: "dgx-spark-ollama", name: "DGX Spark + ollama 初期構築", desc: "DGX OS の初期設定・SSH 堅牢化・ufw から、ollama の LAN 内 API 公開・モデル取得までの手順書（Markdown）を生成。", category: "ai", subCategory: "NVIDIA DGX", format: "yaml", output: "markdown", updated: "2026-07-02", live: true },
+  { id: "zero-trust-access", name: "ゼロトラストアクセス基盤構築", desc: "step-ca + Caddy の mTLS で AI マシンの API / SSH を保護する、商用利用可能な OSS 構成の構築手順書（Markdown）を生成。", category: "ai", subCategory: "step-ca / Caddy", format: "yaml", output: "markdown", updated: "2026-07-02", live: true },
 ];
 
 export const CGTemplates: Template[] = META.map((m) => ({

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -8,6 +8,7 @@ export interface Template {
   name: string;
   desc: string;
   category: TemplateCategory;
+  subCategory: string;
   format: Format;
   output: TemplateOutput;
   updated: string;

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -48,6 +48,27 @@ html {
   .cg-concept .cg-op-arrow { transform: rotate(90deg); }
 }
 
+/* ---- editor: editable filename in the app bar ---- */
+.cg-fname {
+  border: 1px solid transparent;
+  transition: border-color var(--dur-base, .15s), background var(--dur-base, .15s);
+}
+.cg-fname:hover { border-color: var(--cg-border); }
+.cg-fname:focus { border-color: var(--cg-red); background: var(--cg-bg); }
+
+/* ---- entrance animations (overlays + empty state) ----
+   `both` fill keeps the final state; under reduced-motion we snap straight to
+   the end state (opacity 1) so a fade-in never leaves an element invisible. */
+@keyframes cg-overlay-in { from { opacity: 0; } to { opacity: 1; } }
+@keyframes cg-pop-in { from { opacity: 0; transform: translateY(8px) scale(.985); } to { opacity: 1; transform: none; } }
+@keyframes cg-enter-up { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
+.cg-overlay-in { animation: cg-overlay-in 0.18s ease-out both; }
+.cg-pop-in { animation: cg-pop-in 0.22s cubic-bezier(.2,.7,.3,1) both; }
+.cg-enter-up { animation: cg-enter-up 0.5s cubic-bezier(.2,.7,.3,1) both; }
+@media (prefers-reduced-motion: reduce) {
+  .cg-overlay-in, .cg-pop-in, .cg-enter-up { animation: none; opacity: 1; transform: none; }
+}
+
 /* ---- tasteful, workplace-safe "haunting" for the empty state ---- */
 @keyframes cg-bob   { 0%,100% { transform: translateY(0) } 50% { transform: translateY(-9px) } }
 @keyframes cg-glow  { 0%,100% { opacity: .30; transform: scale(1) } 50% { opacity: .55; transform: scale(1.06) } }


### PR DESCRIPTION
## Summary

Second UX round on the `web/` 2-pane editor (after #530). Six items; scope is
`web/src` only. Closes #532.

## Changes

1. **Entrance animations** for the empty screen, the how-to modal, and the
   settings modal (fade/scale-in via CSS keyframes; honors
   `prefers-reduced-motion` by snapping to the visible end state so a fade-in
   never leaves an element invisible).
2. **New empty-screen tagline** "値を変えるだけで、コマンドも手順書も。" replacing the
   previous "… → 再現可能なコマンド" line.
3. **Template library sub-categories** (new feature — no prior implementation
   existed in git history; see #532). Adds `Template.subCategory` and groups the
   card grid into sub-category sections with headings + counts, using each
   category's natural technical axis: network by vendor/product (Cisco, YAMAHA,
   firewalld), server by distro (Ubuntu / Debian), DNS by application (BIND),
   runbooks by target system (ネットワーク, プロキシ / Web), AI infra by product
   (NVIDIA DGX, step-ca / Caddy). Groups are ordered by category (same-category
   sub-categories stay adjacent, incl. the "すべて" view); the left rail is
   unchanged.
4. **Editable filename** in the app-bar header; it is the download filename
   base. The download-filename input is removed from the settings modal.
5. **Extension derived from output mode** (手順書 → .md, Raw → .txt) instead of a
   settings radio; the save button moves to the pane footer, copy stays in the
   header. `DownloadOptions` drops `fname`/`ext`.
6. **Splitter clamp** with per-side minimum widths so neither pane header clips
   (the left header is wider than the right); falls back to 50/50 when the
   window is too small to grant both floors.

## Verification

`tsc -b` + `vite build` + Vitest (41 passed, incl. new component tests for the
download filename/extension logic). Browser checks (Playwright/Chromium) for the
entrance animations, the catchphrase swap, sub-category grouping, and the
splitter clamp at min/max widths. The only failing test is
`pyodide-runtime.node.test.ts`, which fails in this offline environment because
the Pyodide wheels are not vendored — it passes in CI, and is unrelated to this
diff.

Refs #532, #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AnNqAtPC31wodDZmYiRgz4)_