### PR TITLE
ci(deps): switch Dependabot Python ecosystem from pip to uv (#559)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,10 +29,10 @@ updates:
   # bunがサポートされるまでJS依存のDependabot自動更新は一時停止し、`bun update`を手動/別途の
   # 仕組みで運用する。
 
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /
     groups:
-      pip:
+      uv:
         patterns:
           - "*"
     schedule:


### PR DESCRIPTION
## Summary

Switch the Python entry in `.github/dependabot.yml` from
`package-ecosystem: pip` to `package-ecosystem: uv` (and rename the group
`pip` -> `uv`). No other keys change (schedule, grouping pattern,
`target-branch: develop`, and the github-actions / devcontainers ecosystems
are untouched).

## Why

The `pip` ecosystem bumps `pyproject.toml` constraints but never regenerates
`uv.lock`, so every Python Dependabot PR lands with a stale lockfile and CI
fails at `uv sync --locked`:

```
The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

Dependabot's `uv` ecosystem reads `pyproject.toml` AND maintains `uv.lock` in
lockstep, matching this repo's layout (`pyproject.toml` + `uv.lock` +
`[dependency-groups]`). Confirmed against the official Dependabot options
reference: `uv` is a supported `package-ecosystem` value with dependency-group
support.

## History

This switch was merged once before (#380, retrospective #381) but was lost
when `develop` was re-synced onto `main`'s architecture (the "D1" work, #382;
re-sync commits #483 / #484). This PR re-applies it on the current `develop`
history. The invalid `security-updates` key that required a repair last time
(#367) is already absent from the current file, so no validation repair is
expected.

## Verification

- `.github/dependabot.yml` parses as valid YAML; `version: 2`, ecosystems now
  `github-actions`, `uv`, `devcontainers`.
- End-to-end confirmation is the GitHub-side Dependabot config validation check
  on this PR (the only place the schema is enforced) plus the next scheduled
  `uv` run producing a PR whose `uv.lock` passes `uv sync --locked`.

## Scope

Configuration only; no source or test changes.

Closes #559
Refs #379, #380, #381, #382, #367


---
_Generated by [Claude Code](https://claude.ai/code/session_01JgPzUjJGyxVR7RMeKoMZGR)_