### PR TITLE
ci: move uv pin out of [tool.uv].required-version and retire pyproject-fmt (#562, #564)

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -12,9 +12,10 @@ runs:
     - name: Install uv
       uses: astral-sh/setup-uv@v6
       with:
-        # Keep in lockstep with [tool.uv].required-version in pyproject.toml.
-        # That pin is exact (==) because flake.nix asserts the "==" form, so the
-        # installed uv must match exactly or every uv command fails the gate.
+        # Keep in lockstep with [tool.command-ghostwriter].uv-version in
+        # pyproject.toml (the single source of truth that flake.nix also reads).
+        # It is intentionally NOT [tool.uv].required-version -- that pin makes
+        # uv self-abort under Dependabot's uv image (0.11.8). Refs #562.
         version: "0.8.17"
         enable-cache: true
         cache-dependency-glob: "uv.lock"

--- a/.github/workflows/reusable-test-and-build.yml
+++ b/.github/workflows/reusable-test-and-build.yml
@@ -337,10 +337,6 @@ jobs:
         run: |
           uv run ruff check . -v
 
-      - name: Check pyproject.toml formatting
-        run: |
-          uv run pre-commit run pyproject-fmt --all-files
-
       - name: Run Vulture
         run: |
           uv run vulture

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,16 +90,6 @@ repos:
         files: ^\.claude/skills/.*|^apm\.lock\.yaml$
         entry: uv run python scripts/gen_superpowers_manifest.py --check
 
-  - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.5.1
-    hooks:
-      - id: pyproject-fmt
-        description: "Run 'pyproject-fmt' for extremely fast Python formatting"
-        name: fomart pyproject
-        # https://pyproject-fmt.readthedocs.io/en/latest/#calculating-max-supported-python-version
-        additional_dependencies: ["tox>=4.9"]
-        files: ^pyproject\.toml$
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.4
     hooks:

--- a/flake.nix
+++ b/flake.nix
@@ -8,10 +8,14 @@
   outputs = { nixpkgs, ... }:
     let
       systems = [ "aarch64-linux" "x86_64-linux" ];
-      uvVersionSpec = (builtins.fromTOML (builtins.readFile ./pyproject.toml)).tool.uv.required-version;
+      # uv version is pinned in pyproject.toml under our own
+      # [tool.command-ghostwriter] table -- NOT [tool.uv].required-version, which
+      # would make Dependabot's uv image self-abort and block uv.lock updates
+      # (see #562). It is a plain version string used directly in the URL below.
       uvVersion =
-        assert nixpkgs.lib.hasPrefix "==" uvVersionSpec;
-        nixpkgs.lib.removePrefix "==" uvVersionSpec;
+        let raw = (builtins.fromTOML (builtins.readFile ./pyproject.toml)).tool.command-ghostwriter.uv-version;
+        in assert builtins.match "[0-9]+\\.[0-9]+\\.[0-9]+.*" raw != null;
+        raw;
       forAllSystems = nixpkgs.lib.genAttrs systems;
       mkPackages = system:
         let

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,12 +212,12 @@ warn_unreachable = true
 [tool.uv]
 package = false
 
+[tool.command-ghostwriter]
 # Pinned uv version for reproducible provisioning. Single source of truth read
 # by flake.nix (devShell pinned-uv) and mirrored by the setup-python composite
 # action. Deliberately NOT [tool.uv].required-version: that pin makes uv
 # self-abort when Dependabot's uv image (0.11.8) runs, blocking uv.lock
 # regeneration under the `uv` Dependabot ecosystem. Refs #562.
-[tool.command-ghostwriter]
 uv-version = "0.8.17"
 
 [tool.benchmark]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,8 +211,14 @@ warn_unreachable = true
 
 [tool.uv]
 package = false
-# flake.nix がこの値を読む。実装時点の本環境 uv 0.8.17 を初期 pin とする。
-required-version = "==0.8.17"
+
+# Pinned uv version for reproducible provisioning. Single source of truth read
+# by flake.nix (devShell pinned-uv) and mirrored by the setup-python composite
+# action. Deliberately NOT [tool.uv].required-version: that pin makes uv
+# self-abort when Dependabot's uv image (0.11.8) runs, blocking uv.lock
+# regeneration under the `uv` Dependabot ecosystem. Refs #562.
+[tool.command-ghostwriter]
+uv-version = "0.8.17"
 
 [tool.benchmark]
 min_time = 0.1


### PR DESCRIPTION
## Summary

Two related config changes (the second folded in at the owner's request after
pyproject-fmt caused friction on the first):

### 1. Move the uv version pin out of `[tool.uv].required-version` (#562)

Follow-up to #560. The `uv` Dependabot ecosystem runs uv from
`ghcr.io/astral-sh/uv:0.11.8`
(https://github.com/dependabot/dependabot-core/blob/main/uv/Dockerfile), which
cannot satisfy `==0.8.17`. uv aborts project commands on a `required-version`
mismatch, so Dependabot would fail before regenerating `uv.lock`
(dependabot/dependabot-core#13199).

- `pyproject.toml`: drop `[tool.uv].required-version = "==0.8.17"`; add a
  project-owned `[tool.command-ghostwriter].uv-version = "0.8.17"` that uv does
  not interpret.
- `flake.nix`: read the new key (plain version) and assert the version format.
- `.github/actions/setup-python/action.yml`: point the lockstep comment at the
  new source of truth.

Exact `0.8.17` provisioning for the Nix devShell and the setup-python action is
preserved (single source of truth stays in `pyproject.toml`, under a non-uv
key).

### 2. Retire pyproject-fmt (#564)

pyproject-fmt only enforces cosmetic `pyproject.toml` layout and blocked this PR
for a formatting-only blank line. Python lint/format is already covered by ruff,
so the gate's value does not justify the churn.

- `.pre-commit-config.yaml`: remove the `tox-dev/pyproject-fmt` repo/hook.
- `.github/workflows/reusable-test-and-build.yml`: remove the
  `Check pyproject.toml formatting` step. mypy / ruff / vulture / pyre are
  unaffected.

## Verification

- `[tool.uv].required-version` removed; `[tool.command-ghostwriter].uv-version`
  parses to `0.8.17` (`tomllib`). `uv lock --check` passes; `uv.lock`
  unaffected.
- `.pre-commit-config.yaml` and `reusable-test-and-build.yml` parse as valid
  YAML; no `pyproject-fmt` references remain in live config.
- Not verifiable locally: the Nix devShell build (`nix` unavailable in this
  environment; CI does not `nix eval` the full flake -- `scripts/flake_pin.py`
  only regex-reads actionlint/shellcheck pins, untouched here). The devcontainer
  / Nix build is the end-to-end check.

## Scope

Config + flake plumbing + CI/pre-commit only. No app/source/test behavior
change.

Closes #562, #564
Refs #560, #559
Upstream: dependabot/dependabot-core#13199
