### PR TITLE
fix(deps): drop unused pytest-xml plugin breaking pytest 9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ dev = [
   "pytest-rerunfailures>=16.3,<17",
   "pytest-timeout>=2.4,<3",
   "pytest-xdist>=3.8,<4",
-  "pytest-xml>=0.1.1,<0.2",
   "ruff>=0.15.16,<0.16",
   "types-psutil>=7.0.0.20250601,<8",
   "types-pyyaml>=6.0.12.20250516,<7",

--- a/uv.lock
+++ b/uv.lock
@@ -130,7 +130,6 @@ dev = [
     { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
-    { name = "pytest-xml" },
     { name = "ruff" },
     { name = "types-psutil" },
     { name = "types-pyyaml" },
@@ -178,7 +177,6 @@ dev = [
     { name = "pytest-rerunfailures", specifier = ">=16.3,<17" },
     { name = "pytest-timeout", specifier = ">=2.4,<3" },
     { name = "pytest-xdist", specifier = ">=3.8,<4" },
-    { name = "pytest-xml", specifier = ">=0.1.1,<0.2" },
     { name = "ruff", specifier = ">=0.15.16,<0.16" },
     { name = "types-psutil", specifier = ">=7.0.0.20250601,<8" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250516,<7" },
@@ -314,15 +312,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/94/1b30216f84c48b9e0646833f6f2dd75f1169cc04dc45c48fe39e644c89d5/dataclasses-json-0.5.7.tar.gz", hash = "sha256:c2c11bc8214fbf709ffc369d11446ff6945254a7f09128154a7620613d8fda90", size = 30958, upload-time = "2022-03-21T14:49:46.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/7e/2042610dfc8121e8119ad8b94db496d8697e4b0ef7a6e378018a2bd84435/dataclasses_json-0.5.7-py3-none-any.whl", hash = "sha256:bc285b5f892094c3a53d558858a88553dd6a61a11ab1a8128a0e554385dcc5dd", size = 25647, upload-time = "2022-03-21T14:49:40.344Z" },
-]
-
-[[package]]
-name = "dict2xml"
-version = "1.7.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/47/abde6e5c4456f7074ddd2e0dd8bbf111d6de40ff5bb5761a5f6b20ad474b/dict2xml-1.7.8.tar.gz", hash = "sha256:6638da9ad32b0f8be8336d16e0f36a9c3821145e34ed3ef4889822a9b980fb28", size = 15644, upload-time = "2026-01-14T22:28:07.767Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/59/99390417ab1c8c118f6dad436aa9e85509b66ce1a80e130c8b61cf3b15bc/dict2xml-1.7.8-py3-none-any.whl", hash = "sha256:0da9213d78496322a9befaa4f934652315973fbf5437f0c0f70f14fc6d16acc5", size = 9460, upload-time = "2026-01-14T22:28:06.542Z" },
 ]
 
 [[package]]
@@ -1241,18 +1230,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-metadata"
-version = "3.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/85/8c969f8bec4e559f8f2b958a15229a35495f5b4ce499f6b865eac54b878d/pytest_metadata-3.1.1.tar.gz", hash = "sha256:d2a29b0355fbc03f168aa96d41ff88b1a3b44a3b02acbe491801c98a048017c8", size = 9952, upload-time = "2024-02-12T19:38:44.887Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl", hash = "sha256:c8e0844db684ee1c798cfa38908d20d67d0463ecb6137c72e91f418558dd5f4b", size = 11428, upload-time = "2024-02-12T19:38:42.531Z" },
-]
-
-[[package]]
 name = "pytest-mock"
 version = "3.15.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1312,21 +1289,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
-]
-
-[[package]]
-name = "pytest-xml"
-version = "0.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dict2xml" },
-    { name = "jinja2" },
-    { name = "pytest" },
-    { name = "pytest-metadata" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/9d/daeae22b39e8826117dfb4a747b10e7bd4b1bde2d1bd2f42e0720f4261a3/pytest_xml-0.1.1.tar.gz", hash = "sha256:cbeabc9321f83367e430426fe423806d77abe90c9045bd74ccede7ec418b4aa4", size = 32271, upload-time = "2024-11-14T02:52:39.923Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/8a/a43b34131a027a5b9ec7404bb41f96092e4c6f75d4e8ca44099d6f5e90c4/pytest_xml-0.1.1-py3-none-any.whl", hash = "sha256:44f49fd2f86bcfcdd792844762b6a471a4a4a61322143edc074a7af553627ff6", size = 23542, upload-time = "2024-11-14T02:52:38.115Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Removes the unused `pytest-xml` dev dependency (and its now-orphaned transitive `dict2xml`/`pytest-metadata` locked entries) from `pyproject.toml` / `uv.lock`.
- Root cause: `pytest-xml==0.1.1` (its only ever release, unmaintained since 2024-11-14) imports the private `_pytest.config.Notset` symbol at plugin-collection time via its `pytest11` entry point. pytest 9.1 finished removing pytest-9-deprecated internals, which broke that import, so **every** pytest invocation aborted before running a single test:
  ```
  ImportError: cannot import name 'Notset' from '_pytest.config'
  ```
- This is what's failing PR #566 (Dependabot `uv` group bump, which bumps `pytest` 9.0.3 → 9.1.1): https://github.com/tvna/command-ghostwriter/actions/runs/29575933469/job/87870554634
- `pytest-xml`'s `xml` fixture has zero callers anywhere in `tests/` (confirmed via repo-wide grep), so removing it is dead-weight cleanup, not a functional change — and it unblocks the pytest/mypy/ruff bumps in #566 instead of pinning pytest back and deferring the incompatibility.
- The other packages bumped in #566 (notably `mypy` 1.20.2 → 2.3.0) are not implicated: the "Guard Python code quality" job (which runs mypy) already passes on that PR as-is.

Closes #578.

## Test plan

- [x] `uv run --with "pytest==9.1.1" pytest tests/unit -q` — 681 passed (previously failed at collection with the `Notset` ImportError)
- [x] `uv run pytest tests/unit -q` at the locked `pytest==9.0.3` — 681 passed
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run mypy .` — no issues found
- [x] Repo-wide grep confirms no remaining references to `pytest-xml` / `pytest_xml` / `dict2xml`'s removed lock entries

## Follow-up

After merge, PR #566 needs a Dependabot rebase to pick this fix up so its CI goes green (Dependabot rebases automatically on a schedule, or can be triggered immediately with a `·@·d·ependabot r·ebase` comment on that PR).


---
_Generated by [Claude Code](https://claude.ai/code/session_01KdW9NhbvwnxjFH7q4hFVW8)_