### PR TITLE
fix(web): render GFM tables in the 手順書 Markdown preview

### DIFF
--- a/web/src/components/Editor.tsx
+++ b/web/src/components/Editor.tsx
@@ -615,6 +615,32 @@ function renderInline(text: string, keyBase: string): ReactNode[] {
   return nodes;
 }
 
+// A GFM table row: starts and ends with `|`. Cell splitting drops the empty
+// strings produced by the leading/trailing pipe.
+const TABLE_ROW_RE = /^\s*\|.*\|\s*$/;
+// A GFM separator row, e.g. `|---|---|` or `| :--- | ---: | :---: |`.
+const TABLE_SEPARATOR_RE = /^\s*\|?\s*:?-{1,}:?\s*(\|\s*:?-{1,}:?\s*)*\|?\s*$/;
+
+function parseTableRow(line: string): string[] {
+  let s = line.trim();
+  if (s.startsWith('|')) s = s.slice(1);
+  if (s.endsWith('|')) s = s.slice(0, -1);
+  return s.split('|').map((c) => c.trim());
+}
+
+type ColumnAlign = 'left' | 'center' | 'right' | undefined;
+
+function parseColumnAligns(separatorLine: string): ColumnAlign[] {
+  return parseTableRow(separatorLine).map((c) => {
+    const left = c.startsWith(':');
+    const right = c.endsWith(':');
+    if (left && right) return 'center';
+    if (right) return 'right';
+    if (left) return 'left';
+    return undefined;
+  });
+}
+
 function MarkdownView({ output }: { output: string }) {
   const lines = output.split('\n');
   const blocks: ReactNode[] = [];
@@ -678,6 +704,44 @@ function MarkdownView({ output }: { output: string }) {
             <li key={j}>{renderInline(it, 'o' + key + j)}</li>
           ))}
         </ol>,
+      );
+      continue;
+    }
+    if (TABLE_ROW_RE.test(line) && i + 1 < lines.length && TABLE_SEPARATOR_RE.test(lines[i + 1])) {
+      const headerCells = parseTableRow(line);
+      const aligns = parseColumnAligns(lines[i + 1]);
+      i += 2;
+      const rows: string[][] = [];
+      while (i < lines.length && TABLE_ROW_RE.test(lines[i])) {
+        rows.push(parseTableRow(lines[i]));
+        i++;
+      }
+      const tKey = key++;
+      blocks.push(
+        <div key={tKey} style={{ overflowX: 'auto', margin: '0 0 14px' }}>
+          <table style={{ borderCollapse: 'collapse', fontSize: 'var(--text-sm)', color: 'var(--cg-text)', minWidth: '100%' }}>
+            <thead>
+              <tr>
+                {headerCells.map((c, j) => (
+                  <th key={j} style={{ textAlign: aligns[j] ?? 'left', padding: '6px 12px', borderBottom: '2px solid var(--cg-border-strong)', whiteSpace: 'nowrap' }}>
+                    {renderInline(c, 'th' + tKey + '-' + j)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r, ri) => (
+                <tr key={ri} style={{ borderBottom: '1px solid var(--cg-border)' }}>
+                  {r.map((c, ci) => (
+                    <td key={ci} style={{ textAlign: aligns[ci] ?? 'left', padding: '6px 12px' }}>
+                      {renderInline(c, 'td' + tKey + '-' + ri + '-' + ci)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>,
       );
       continue;
     }

--- a/web/src/components/Editor.tsx
+++ b/web/src/components/Editor.tsx
@@ -718,12 +718,21 @@ function MarkdownView({ output }: { output: string }) {
       }
       const tKey = key++;
       blocks.push(
-        <div key={tKey} style={{ overflowX: 'auto', margin: '0 0 14px' }}>
+        <div key={tKey} style={{ overflowX: 'auto', margin: '0 0 14px', border: '1px solid var(--cg-border)', borderRadius: 'var(--radius-md)' }}>
           <table style={{ borderCollapse: 'collapse', fontSize: 'var(--text-sm)', color: 'var(--cg-text)', minWidth: '100%' }}>
             <thead>
               <tr>
                 {headerCells.map((c, j) => (
-                  <th key={j} style={{ textAlign: aligns[j] ?? 'left', padding: '6px 12px', borderBottom: '2px solid var(--cg-border-strong)', whiteSpace: 'nowrap' }}>
+                  <th
+                    key={j}
+                    style={{
+                      textAlign: aligns[j] ?? 'left',
+                      padding: '6px 12px',
+                      borderBottom: '2px solid var(--cg-border-strong)',
+                      borderRight: j < headerCells.length - 1 ? '1px solid var(--cg-border)' : undefined,
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
                     {renderInline(c, 'th' + tKey + '-' + j)}
                   </th>
                 ))}
@@ -731,9 +740,16 @@ function MarkdownView({ output }: { output: string }) {
             </thead>
             <tbody>
               {rows.map((r, ri) => (
-                <tr key={ri} style={{ borderBottom: '1px solid var(--cg-border)' }}>
+                <tr key={ri} style={{ borderBottom: ri < rows.length - 1 ? '1px solid var(--cg-border)' : undefined }}>
                   {r.map((c, ci) => (
-                    <td key={ci} style={{ textAlign: aligns[ci] ?? 'left', padding: '6px 12px' }}>
+                    <td
+                      key={ci}
+                      style={{
+                        textAlign: aligns[ci] ?? 'left',
+                        padding: '6px 12px',
+                        borderRight: ci < r.length - 1 ? '1px solid var(--cg-border)' : undefined,
+                      }}
+                    >
                       {renderInline(c, 'td' + tKey + '-' + ri + '-' + ci)}
                     </td>
                   ))}


### PR DESCRIPTION
## Summary

- `MarkdownView` in `web/src/components/Editor.tsx` (the 手順書 tab's Markdown-to-React renderer) had no GFM table support: a table's header row, `|---|---|` separator, and every data row each fell through to the generic plain-paragraph branch, so tables rendered as stacked unaligned lines instead of a grid — with the separator row shown as literal visible text.
- This is pre-existing and repo-wide, not specific to any one template: reproduced on `rack-power-budget` (merged well before this fix, via PR #603). It affects most of the ~719 templates in the library, since the majority include at least one table in their generated output.
- Adds table-block detection to `MarkdownView`: a header row followed by a GFM-shaped separator row is now parsed and rendered as an actual `<table>`, including column alignment from the separator (`:---`, `---:`, `:---:`). Kept in the same hand-rolled-renderer style as the rest of the function (no new dependency).

## Test plan

- [x] `npx tsc -b` — no errors
- [x] `npx vitest run` — 47 passed
- [x] Built the app (`npm run build`) and served it locally (`vite preview`); drove it with Playwright to open `rack-power-budget` (facility, has a table) and confirmed the table now renders as an aligned grid in the 手順書 tab, matching how it renders on GitHub

Refs #607


---
_Generated by [Claude Code](https://claude.ai/code/session_013WfnKXDMbcbD9GHoGdT2rh)_